### PR TITLE
[FIX] 주문 완료 -> 결제 페이지로 넘어갈 때 URL 수정

### DIFF
--- a/src/main/java/store/ckin/api/book/entity/Book.java
+++ b/src/main/java/store/ckin/api/book/entity/Book.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import store.ckin.api.book.relationship.bookauthor.entity.BookAuthor;
 import store.ckin.api.book.relationship.bookcategory.entity.BookCategory;
 import store.ckin.api.book.relationship.booktag.entity.BookTag;
@@ -27,6 +28,8 @@ import store.ckin.api.file.entity.File;
  * @author 나국로
  * @version 2024. 02. 26.
  */
+
+@ToString
 @Entity
 @Getter
 @NoArgsConstructor

--- a/src/main/java/store/ckin/api/booksale/dto/response/BookSaleResponseDto.java
+++ b/src/main/java/store/ckin/api/booksale/dto/response/BookSaleResponseDto.java
@@ -2,7 +2,6 @@ package store.ckin.api.booksale.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
 
 /**
  * 도서 주문 응답 DTO 클래스입니다.
@@ -11,7 +10,6 @@ import lombok.ToString;
  * @version 2024. 03. 07.
  */
 
-@ToString
 @Getter
 @AllArgsConstructor
 public class BookSaleResponseDto {

--- a/src/main/java/store/ckin/api/booksale/entity/BookSale.java
+++ b/src/main/java/store/ckin/api/booksale/entity/BookSale.java
@@ -14,6 +14,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 /**
  * 주문 도서 (리스트) Entity.
@@ -56,6 +57,7 @@ public class BookSale {
     private BookSaleState bookSaleState;
 
     @Embeddable
+    @ToString
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor

--- a/src/main/java/store/ckin/api/sale/controller/SaleController.java
+++ b/src/main/java/store/ckin/api/sale/controller/SaleController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
+import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
 import store.ckin.api.sale.facade.SaleFacade;
@@ -91,7 +92,18 @@ public class SaleController {
      */
     @GetMapping("/{saleId}/books")
     public ResponseEntity<SaleWithBookResponseDto> getSaleWithBooks(@PathVariable Long saleId) {
-        SaleWithBookResponseDto responseDto = saleFacade.SaleWithBookResponseDto(saleId);
+        SaleWithBookResponseDto responseDto = saleFacade.getSaleWithBookResponseDto(saleId);
         return ResponseEntity.ok(responseDto);
+    }
+
+    /**
+     * 주문 번호로 결제할 주문의 정보를 조회하는 메서드입니다.
+     *
+     * @param saleNumber 주문 번호 (UUID)
+     * @return 200 (OK), 주문 정보
+     */
+    @GetMapping("/{saleNumber}/paymentInfo")
+    public ResponseEntity<SaleInfoResponseDto> getSalePaymentInfo(@PathVariable("saleNumber") String saleNumber) {
+        return ResponseEntity.ok(saleFacade.getSalePaymentInfo(saleNumber));
     }
 }

--- a/src/main/java/store/ckin/api/sale/dto/response/SaleInfoResponseDto.java
+++ b/src/main/java/store/ckin/api/sale/dto/response/SaleInfoResponseDto.java
@@ -1,0 +1,28 @@
+package store.ckin.api.sale.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 주문 정보 응답 DTO.
+ *
+ * @author 정승조
+ * @version 2024. 03. 09.
+ */
+
+@Getter
+@AllArgsConstructor
+public class SaleInfoResponseDto {
+
+    private String saleTitle;
+
+    private String saleNumber;
+
+    private String memberEmail;
+
+    private String saleOrdererName;
+
+    private String saleOrdererContact;
+
+    private Integer totalPrice;
+}

--- a/src/main/java/store/ckin/api/sale/dto/response/SaleWithBookResponseDto.java
+++ b/src/main/java/store/ckin/api/sale/dto/response/SaleWithBookResponseDto.java
@@ -80,4 +80,15 @@ public class SaleWithBookResponseDto {
 
         this.saleTitle = saleTitle + " 외 " + (bookSaleList.size() - 1) + "권";
     }
+
+    public SaleInfoResponseDto extractSaleInfoResponseDto() {
+        return new SaleInfoResponseDto(
+                saleTitle,
+                saleNumber,
+                memberEmail,
+                saleOrdererName,
+                saleOrdererContact,
+                totalPrice
+        );
+    }
 }

--- a/src/main/java/store/ckin/api/sale/exception/SaleNumberNotFoundException.java
+++ b/src/main/java/store/ckin/api/sale/exception/SaleNumberNotFoundException.java
@@ -1,0 +1,15 @@
+package store.ckin.api.sale.exception;
+
+/**
+ * 주문번호로 조회된 주문이 없는 경우에 발생하는 예외입니다.
+ *
+ * @author 정승조
+ * @version 2024. 03. 09.
+ */
+
+public class SaleNumberNotFoundException extends RuntimeException {
+
+    public SaleNumberNotFoundException(String saleNumber) {
+        super(String.format("주문 정보가 존재하지 않습니다. (주문번호 = %s)", saleNumber));
+    }
+}

--- a/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
+++ b/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
@@ -11,6 +11,7 @@ import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.member.service.MemberService;
 import store.ckin.api.sale.dto.request.SaleCreateNoBookRequestDto;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
+import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
 import store.ckin.api.sale.service.SaleService;
@@ -96,7 +97,19 @@ public class SaleFacade {
      * @param saleId 주문 ID
      * @return 주문 상세 정보와 주문한 책 정보
      */
-    public SaleWithBookResponseDto SaleWithBookResponseDto(Long saleId) {
+    @Transactional(readOnly = true)
+    public SaleWithBookResponseDto getSaleWithBookResponseDto(Long saleId) {
         return saleService.getSaleWithBook(saleId);
+    }
+
+    /**
+     * 주문 번호로 결제할 주문의 정보를 조회하는 메서드입니다.
+     *
+     * @param saleNumber 주문 번호 (UUID)
+     * @return 주문 정보
+     */
+    @Transactional(readOnly = true)
+    public SaleInfoResponseDto getSalePaymentInfo(String saleNumber) {
+        return saleService.getSalePaymentInfo(saleNumber);
     }
 }

--- a/src/main/java/store/ckin/api/sale/repository/SaleRepository.java
+++ b/src/main/java/store/ckin/api/sale/repository/SaleRepository.java
@@ -20,4 +20,14 @@ public interface SaleRepository extends JpaRepository<Sale, Long>, SaleRepositor
      * @return 주문 목록
      */
     Page<Sale> findAllByOrderBySaleIdDesc(Pageable pageable);
+
+    /**
+     * 주문 번호로 주문을 조회합니다.
+     *
+     * @param saleNumber 주문 번호 (UUID)
+     * @return 주문 존재 여부
+     */
+    boolean existsBySaleNumber(String saleNumber);
+
+    Sale getBySaleNumber(String saleNumber);
 }

--- a/src/main/java/store/ckin/api/sale/repository/SaleRepositoryCustom.java
+++ b/src/main/java/store/ckin/api/sale/repository/SaleRepositoryCustom.java
@@ -29,4 +29,6 @@ public interface SaleRepositoryCustom {
      * @return 주문 상세 정보와 주문한 책 정보 DTO
      */
     SaleWithBookResponseDto getSaleWithBook(Long saleId);
+
+
 }

--- a/src/main/java/store/ckin/api/sale/repository/SaleRepositoryImpl.java
+++ b/src/main/java/store/ckin/api/sale/repository/SaleRepositoryImpl.java
@@ -93,6 +93,7 @@ public class SaleRepositoryImpl extends QuerydslRepositorySupport implements Sal
                                 bookSale.bookSalePaymentAmount))
                         .fetch();
 
+
         SaleWithBookResponseDto responseDto =
                 from(sale)
                         .where(sale.saleId.eq(saleId))
@@ -104,8 +105,8 @@ public class SaleRepositoryImpl extends QuerydslRepositorySupport implements Sal
                                 sale.member.email,
                                 sale.saleOrdererName,
                                 sale.saleOrdererContact,
-                                sale.saleReceiverContact,
                                 sale.saleReceiverName,
+                                sale.saleReceiverContact,
                                 sale.saleDeliveryFee,
                                 sale.saleDeliveryDate,
                                 sale.saleShippingPostCode,
@@ -118,7 +119,6 @@ public class SaleRepositoryImpl extends QuerydslRepositorySupport implements Sal
         for (BookSaleResponseDto bookSaleResponseDto : bookSaleResponseDtoList) {
             responseDto.addBookSale(bookSaleResponseDto);
         }
-
 
         String saleTitle = from(book)
                 .where(book.bookId.eq(bookSaleResponseDtoList.get(0).getBookId()))

--- a/src/main/java/store/ckin/api/sale/service/SaleService.java
+++ b/src/main/java/store/ckin/api/sale/service/SaleService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.sale.dto.request.SaleCreateNoBookRequestDto;
+import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
 
@@ -56,4 +57,12 @@ public interface SaleService {
      * @return 주문 상세 정보와 주문한 책 정보 DTO
      */
     SaleWithBookResponseDto getSaleWithBook(Long saleId);
+
+    /**
+     * 주문 결제 정보를 조회하는 메서드입니다.
+     *
+     * @param saleNumber 주문 번호 (UUID)
+     * @return 주문 결제 정보 DTO
+     */
+    SaleInfoResponseDto getSalePaymentInfo(String saleNumber);
 }

--- a/src/main/java/store/ckin/api/sale/service/impl/SaleServiceImpl.java
+++ b/src/main/java/store/ckin/api/sale/service/impl/SaleServiceImpl.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -17,10 +16,12 @@ import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.member.entity.Member;
 import store.ckin.api.member.repository.MemberRepository;
 import store.ckin.api.sale.dto.request.SaleCreateNoBookRequestDto;
+import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
 import store.ckin.api.sale.entity.Sale;
 import store.ckin.api.sale.exception.SaleNotFoundException;
+import store.ckin.api.sale.exception.SaleNumberNotFoundException;
 import store.ckin.api.sale.repository.SaleRepository;
 import store.ckin.api.sale.service.SaleService;
 
@@ -31,7 +32,6 @@ import store.ckin.api.sale.service.SaleService;
  * @version 2024. 03. 02.
  */
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SaleServiceImpl implements SaleService {
@@ -50,8 +50,6 @@ public class SaleServiceImpl implements SaleService {
     @Transactional
     public Long createSale(SaleCreateNoBookRequestDto requestDto) {
 
-        log.debug("{} : {}", this.getClass().getName(), requestDto.getAddress());
-
         Optional<Member> member = Optional.empty();
         if (Objects.nonNull(requestDto.getMemberId())) {
             member = memberRepository.findById(requestDto.getMemberId());
@@ -59,30 +57,20 @@ public class SaleServiceImpl implements SaleService {
 
 
         String saleNumber = UUID.randomUUID().toString().replace("-", "").substring(0, 20);
-        Sale sale = Sale.builder()
-                .member(member.orElse(null))
-                .saleNumber(saleNumber)
-                .saleOrdererName(requestDto.getSaleOrderName())
-                .saleOrdererContact(requestDto.getSaleOrderContact())
+        Sale sale = Sale.builder().member(member.orElse(null)).saleNumber(saleNumber)
+                .saleOrdererName(requestDto.getSaleOrderName()).saleOrdererContact(requestDto.getSaleOrderContact())
                 .saleReceiverName(requestDto.getSaleReceiverName())
                 .saleReceiverContact(requestDto.getSaleReceiverContact())
                 .saleReceiverAddress(requestDto.getAddress() + " " + requestDto.getDetailAddress())
-                .saleDate(LocalDateTime.now())
-                .saleShippingDate(LocalDateTime.now().plusDays(1))
-                .saleDeliveryDate(requestDto.getSaleDeliveryDate())
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
-                .saleDeliveryFee(requestDto.getDeliveryFee())
-                .salePointUsage(requestDto.getPointUsage())
-                .saleTotalPrice(requestDto.getTotalPrice())
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
-                .saleShippingPostCode(requestDto.getPostcode())
-                .build();
+                .saleDate(LocalDateTime.now()).saleShippingDate(LocalDateTime.now().plusDays(1))
+                .saleDeliveryDate(requestDto.getSaleDeliveryDate()).saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryFee(requestDto.getDeliveryFee()).salePointUsage(requestDto.getPointUsage())
+                .saleTotalPrice(requestDto.getTotalPrice()).salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .saleShippingPostCode(requestDto.getPostcode()).build();
 
-        log.debug("주문 생성: {}", sale);
 
         Sale save = saleRepository.save(sale);
 
-        log.debug("주문 생성 완료: {}", save);
         return save.getSaleId();
     }
 
@@ -96,16 +84,11 @@ public class SaleServiceImpl implements SaleService {
     public PagedResponse<List<SaleResponseDto>> getSales(Pageable pageable) {
         Page<Sale> salePage = saleRepository.findAllByOrderBySaleIdDesc(pageable);
 
-        PageInfo pageInfo = PageInfo.builder()
-                .page(pageable.getPageNumber())
-                .size(pageable.getPageSize())
-                .totalElements((int) salePage.getTotalElements())
-                .totalPages(salePage.getTotalPages())
-                .build();
+        PageInfo pageInfo = PageInfo.builder().page(pageable.getPageNumber()).size(pageable.getPageSize())
+                .totalElements((int) salePage.getTotalElements()).totalPages(salePage.getTotalPages()).build();
 
         List<SaleResponseDto> currentPageSalesResponse =
-                salePage.getContent().stream().map(SaleResponseDto::toDto).collect(
-                        Collectors.toList());
+                salePage.getContent().stream().map(SaleResponseDto::toDto).collect(Collectors.toList());
 
         return new PagedResponse<>(currentPageSalesResponse, pageInfo);
     }
@@ -128,15 +111,25 @@ public class SaleServiceImpl implements SaleService {
         return saleRepository.findBySaleId(saleId);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param saleId 주문 ID
+     */
     @Override
     @Transactional
     public void updateSalePaymentPaidStatus(Long saleId) {
-        Sale sale = saleRepository.findById(saleId)
-                .orElseThrow(() -> new SaleNotFoundException(saleId));
+        Sale sale = saleRepository.findById(saleId).orElseThrow(() -> new SaleNotFoundException(saleId));
 
         sale.updatePaymentStatus(Sale.PaymentStatus.PAID);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param saleId 주문 ID
+     * @return 주문 상세 정보와 주문한 책 정보 DTO
+     */
     @Override
     @Transactional(readOnly = true)
     public SaleWithBookResponseDto getSaleWithBook(Long saleId) {
@@ -146,5 +139,24 @@ public class SaleServiceImpl implements SaleService {
         }
 
         return saleRepository.getSaleWithBook(saleId);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param saleNumber 주문 번호 (UUID)
+     * @return 주문 결제 정보 DTO
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public SaleInfoResponseDto getSalePaymentInfo(String saleNumber) {
+
+        if (!saleRepository.existsBySaleNumber(saleNumber)) {
+            throw new SaleNumberNotFoundException(saleNumber);
+        }
+
+        Long saleId = saleRepository.getBySaleNumber(saleNumber).getSaleId();
+
+        return saleRepository.getSaleWithBook(saleId).extractSaleInfoResponseDto();
     }
 }

--- a/src/test/java/store/ckin/api/sale/controller/SaleControllerTest.java
+++ b/src/test/java/store/ckin/api/sale/controller/SaleControllerTest.java
@@ -2,6 +2,7 @@ package store.ckin.api.sale.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,7 +29,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import store.ckin.api.common.domain.PageInfo;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
+import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
+import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
 import store.ckin.api.sale.entity.Sale;
 import store.ckin.api.sale.facade.SaleFacade;
 
@@ -205,5 +208,83 @@ class SaleControllerTest {
                 .andDo(print());
 
         verify(saleFacade, times(1)).updateSalePaymentPaidStatus(1L);
+    }
+
+    @Test
+    @DisplayName("주문 ID로 주문 상세 정보와 주문한 책 정보 조회 테스트")
+    void testGetSaleWithBooks() throws Exception {
+
+        SaleWithBookResponseDto responseDto = new SaleWithBookResponseDto(
+                1L,
+                "ABC1234DEF",
+                "test@test.com",
+                "Tester",
+                "01012341234",
+                "Tester",
+                "01011112222",
+                3000,
+                LocalDate.now().plusDays(1),
+                "12345",
+                "광주광역시 동구 조선대 5길",
+                0,
+                10000
+        );
+
+
+        given(saleFacade.getSaleWithBookResponseDto(anyLong()))
+                .willReturn(responseDto);
+        mockMvc.perform(get("/api/sales/{saleId}/books", 1L))
+
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("$.saleId").value(responseDto.getSaleId()),
+                        jsonPath("$.saleNumber").value(responseDto.getSaleNumber()),
+                        jsonPath("$.memberEmail").value(responseDto.getMemberEmail()),
+                        jsonPath("$.saleOrdererName").value(responseDto.getSaleOrdererName()),
+                        jsonPath("$.saleOrdererContact").value(responseDto.getSaleOrdererContact()),
+                        jsonPath("$.saleReceiverName").value(responseDto.getSaleReceiverName()),
+                        jsonPath("$.saleReceiverContact").value(responseDto.getSaleReceiverContact()),
+                        jsonPath("$.deliveryFee").value(responseDto.getDeliveryFee()),
+                        jsonPath("$.saleDeliveryDate").value(responseDto.getSaleDeliveryDate().toString()),
+                        jsonPath("$.postcode").value(responseDto.getPostcode()),
+                        jsonPath("$.address").value(responseDto.getAddress()),
+                        jsonPath("$.pointUsage").value(responseDto.getPointUsage()),
+                        jsonPath("$.totalPrice").value(responseDto.getTotalPrice())
+                ).andDo(print());
+
+        verify(saleFacade, times(1)).getSaleWithBookResponseDto(anyLong());
+    }
+
+    @Test
+    @DisplayName("결제할 주문 정보 조회 테스트")
+    void testGetSalePaymentInfo() throws Exception {
+
+        SaleInfoResponseDto responseDto =
+                new SaleInfoResponseDto(
+                        "홍길동전 외 3권",
+                        "ABC1234DEF",
+                        "test@test.com",
+                        "Tester",
+                        "01012341234",
+                        45000
+                );
+
+        given(saleFacade.getSalePaymentInfo(anyString()))
+                .willReturn(responseDto);
+
+        mockMvc.perform(get("/api/sales/{saleNumber}/paymentInfo", "ABC1234DEF"))
+                .andExpectAll(
+                        status().isOk(),
+                        content().contentType(MediaType.APPLICATION_JSON),
+                        jsonPath("$.saleTitle").value(responseDto.getSaleTitle()),
+                        jsonPath("$.saleNumber").value(responseDto.getSaleNumber()),
+                        jsonPath("$.memberEmail").value(responseDto.getMemberEmail()),
+                        jsonPath("$.saleOrdererName").value(responseDto.getSaleOrdererName()),
+                        jsonPath("$.saleOrdererContact").value(responseDto.getSaleOrdererContact()),
+                        jsonPath("$.totalPrice").value(responseDto.getTotalPrice())
+                ).andDo(print());
+
+        verify(saleFacade, times(1)).getSalePaymentInfo(anyString());
     }
 }

--- a/src/test/java/store/ckin/api/sale/facade/SaleFacadeTest.java
+++ b/src/test/java/store/ckin/api/sale/facade/SaleFacadeTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 import store.ckin.api.booksale.dto.request.BookSaleCreateRequestDto;
+import store.ckin.api.booksale.entity.BookSale;
 import store.ckin.api.booksale.service.BookSaleService;
 import store.ckin.api.member.service.MemberService;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
@@ -120,7 +121,25 @@ class SaleFacadeTest {
 
         saleFacade.updateSalePaymentPaidStatus(1L);
 
+        verify(bookSaleService, times(1)).updateBookSaleState(1L, BookSale.BookSaleState.COMPLETE);
         verify(saleService, times(1)).updateSalePaymentPaidStatus(1L);
     }
 
+    @Test
+    @DisplayName("주문 ID로 주문 상세 정보와 주문한 책 정보 조회 테스트")
+    void testGetSaleWithBookResponse() {
+
+        saleFacade.getSaleWithBookResponseDto(1L);
+
+        verify(saleService, times(1)).getSaleWithBook(1L);
+    }
+
+    @Test
+    @DisplayName("주문 결제 정보 조회 테스트")
+    void testGetSalePaymentInfo() {
+
+        saleFacade.getSalePaymentInfo("123456");
+
+        verify(saleService, times(1)).getSalePaymentInfo("123456");
+    }
 }


### PR DESCRIPTION

## 📝 작업 내용

주문 완료 페이지에서 결제 페이지로 넘어갈 때
`PK(Auto Increment)`로 된 값으로 URL을 설정하니 다른 사람의 결제 페이지로 넘어갈 수 있는 문제점이 존재하였습니다.

이러한 문제점을 UUID로 생성한 `주문 번호(sale_number)`를 사용하여 변경하였습니다.

### 기존 URL
![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/32b13a84-5dc5-43c1-a8c5-16efddb47025)


### 수정 URL
![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/30fbac4c-e8c6-4766-9793-ae2845f1e0b8)

