### PR TITLE
[FEAT] Spring RestDocs 추가

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
+
+        <!-- Rest Docs -->
+        <dependency>
+            <groupId>org.springframework.restdocs</groupId>
+            <artifactId>spring-restdocs-mockmvc</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -192,6 +199,56 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>generate-docs</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html</backend>
+                            <doctype>book</doctype>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.springframework.restdocs</groupId>
+                        <artifactId>spring-restdocs-asciidoctor</artifactId>
+                        <version>${spring-restdocs.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.7</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>
+                                ${project.build.outputDirectory}/static/docs
+                            </outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>
+                                        ${project.build.directory}/generated-docs
+                                    </directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,53 @@
+= CKIN REST-API docs
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc-title: 목차
+:toc: left
+:toclevels: 5
+
+= 1. 개요
+이 API 문서는 CKIN(체크인) 팀의 API 문서를 유용하게 볼수 있게 도와줍니다.
+
+NOTE: 기본적인 구성은 다음과 같습니다
+
+### 1.1 API 구성
+
+```
+/api/**
+```
+
+### 1.2 Domain Name 구성
+
+```
+ckin.store
+```
+
+### 1.3 참여 인원
+
+[cols=2*]
+|===
+| *이름*
+| *GitHub 주소*
+
+| 김준현
+| https://github.com/dduneon
+
+| 정승조
+| https://github.com/f1v3-dev
+
+| 이진우
+| https://github.com/devhomh
+
+| 나국로
+| https://github.com/nayoseb
+
+| 이가은
+| https://github.com/nueag
+|===
+
+'''
+
+= 2. API
+
+include::tag.adoc[]

--- a/src/docs/asciidoc/tag.adoc
+++ b/src/docs/asciidoc/tag.adoc
@@ -1,0 +1,108 @@
+== 태그
+
+=== 태그 생성
+
+==== Request
+
+include::{snippets}/tag/saveTag/success/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/tag/saveTag/success/http-response.adoc[]
+
+==== Request Parameters
+
+include::{snippets}/tag/saveTag/success/request-fields.adoc[]
+
+===== 태그 생성 실패 - 검증 실패
+
+==== Request
+
+include::{snippets}/tag/saveTag/validation-failed/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/tag/saveTag/validation-failed/http-response.adoc[]
+
+===== 태그 생성 실패 - 이미 존재하는 태그
+
+==== Request
+
+include::{snippets}/tag/saveTag/already-exist/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/tag/saveTag/already-exist/http-response.adoc[]
+
+=== 전체 태그 조회
+
+==== Request
+
+include::{snippets}/tag/getTagList/success/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/tag/getTagList/success/http-response.adoc[]
+
+==== Request Parameters
+
+include::{snippets}/tag/getTagList/success/request-parameters.adoc[]
+
+=== 태그 수정
+
+==== Request
+
+include::{snippets}/tag/updateTag/success/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/tag/updateTag/success/http-response.adoc[]
+
+==== Request Parameters
+
+include::{snippets}/tag/updateTag/success/request-fields.adoc[]
+
+===== 태그 수정 실패 - 검증 실패
+
+==== Request
+
+include::{snippets}/tag/updateTag/validation-failed/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/tag/updateTag/validation-failed/http-response.adoc[]
+
+=== 태그 삭제
+
+==== Request
+
+include::{snippets}/tag/deleteTag/success/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/tag/deleteTag/success/http-response.adoc[]
+
+==== Request Field
+
+include::{snippets}/tag/deleteTag/success/request-fields.adoc[]
+
+===== 태그 삭제 실패 - 존재하지 않는 태그
+
+==== Request
+
+include::{snippets}/tag/deleteTag/not-found/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/tag/deleteTag/not-found/http-response.adoc[]
+
+===== 태그 삭제 실패 - 검증 실패
+
+==== Request
+
+include::{snippets}/tag/deleteTag/validation-failed/http-request.adoc[]
+
+==== Response
+
+include::{snippets}/tag/deleteTag/validation-failed/http-response.adoc[]
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#118 

## 📝 작업 내용

Spring Rest Docs를 사용하여 API 문서화를 진행하기 위한 환경 설정 하였습니다

관련 내용은 조만간 기술 공유 하겠습니다~!

- [x] Spring-Rest-Docs 의존성 추가
- [x] 테스트 메서드 수정 (태그)
- [x] Rest Docs 메인 페이지 작성
