### PR TITLE
[FEAT] 주문 취소

### DIFF
--- a/src/main/java/store/ckin/api/booksale/entity/BookSale.java
+++ b/src/main/java/store/ckin/api/booksale/entity/BookSale.java
@@ -33,12 +33,14 @@ import store.ckin.api.sale.entity.Sale;
 @Getter
 @Entity
 @Table(name = "BookSale")
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BookSale {
 
 
     public enum BookSaleState {
-        ORDER, RETURN, CANCEL, COMPLETE
+        ORDER, CANCEL
     }
 
     @EmbeddedId
@@ -87,22 +89,6 @@ public class BookSale {
         @Column(name = "book_id")
         private Long bookId;
     }
-
-    @Builder
-    public BookSale(Pk pk, Sale sale, Book book, Long couponId, Integer bookSaleQuantity,
-                    Integer bookSalePackagingPrice,
-                    String bookSalePackagingType, Integer bookSalePaymentAmount, BookSaleState bookSaleState) {
-        this.pk = pk;
-        this.sale = sale;
-        this.book = book;
-        this.couponId = couponId;
-        this.bookSaleQuantity = bookSaleQuantity;
-        this.bookSalePackagingPrice = bookSalePackagingPrice;
-        this.bookSalePackagingType = bookSalePackagingType;
-        this.bookSalePaymentAmount = bookSalePaymentAmount;
-        this.bookSaleState = bookSaleState;
-    }
-
 
     public void updateBookSaleState(BookSaleState state) {
         this.bookSaleState = state;

--- a/src/main/java/store/ckin/api/member/service/MemberService.java
+++ b/src/main/java/store/ckin/api/member/service/MemberService.java
@@ -48,8 +48,17 @@ public interface MemberService {
     /**
      * [회원 등급의 적립률 * 주문금액]만큼 적립 포인트를 업데이트하는 메서드입니다.
      *
+     * @param saleId     주문 ID
      * @param email      회원 이메일
      * @param totalPrice 총 가격
      */
-    void updateRewardPoint(String email, Integer totalPrice);
+    void updateRewardPoint(Long saleId, String email, Integer totalPrice);
+
+    /**
+     * 취소된 주문의 포인트를 업데이트하는 메서드입니다.
+     *
+     * @param saleId         주문 ID
+     * @param memberEmail    회원 이메일
+     */
+    void updateCancelSalePoint(Long saleId, String memberEmail);
 }

--- a/src/main/java/store/ckin/api/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/store/ckin/api/member/service/impl/MemberServiceImpl.java
@@ -177,6 +177,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public void updateCancelSalePoint(Long saleId, String memberEmail) {
         Member member = memberRepository.findByEmail(memberEmail)
                 .orElseThrow(() -> new MemberNotFoundException(memberEmail));

--- a/src/main/java/store/ckin/api/payment/controller/PaymentController.java
+++ b/src/main/java/store/ckin/api/payment/controller/PaymentController.java
@@ -35,11 +35,8 @@ public class PaymentController {
      */
     @PostMapping
     public ResponseEntity<PaymentSuccessResponseDto> createPayment(@RequestBody PaymentRequestDto requestDto) {
-        // 결제 SAVE
-        PaymentSuccessResponseDto payment = paymentFacade.createPayment(requestDto);
 
-        // 포인트 적립 + 포인트 기록
-        paymentFacade.createRewardPoint(payment.getSaleNumber());
+        PaymentSuccessResponseDto payment = paymentFacade.createPayment(requestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(payment);
     }
 }

--- a/src/main/java/store/ckin/api/payment/dto/request/PaymentRequestDto.java
+++ b/src/main/java/store/ckin/api/payment/dto/request/PaymentRequestDto.java
@@ -3,6 +3,7 @@ package store.ckin.api.payment.dto.request;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import store.ckin.api.payment.entity.PaymentStatus;
 
 /**
  * 결제 요청 DTO 클래스입니다.
@@ -19,7 +20,7 @@ public class PaymentRequestDto {
 
     private String saleNumber;
 
-    private String paymentStatus;
+    private PaymentStatus paymentStatus;
 
     private LocalDateTime requestedAt;
 

--- a/src/main/java/store/ckin/api/payment/dto/response/PaymentResponseDto.java
+++ b/src/main/java/store/ckin/api/payment/dto/response/PaymentResponseDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
+import store.ckin.api.payment.entity.PaymentStatus;
 
 /**
  * 결제 조회 응답 DTO.
@@ -23,7 +24,7 @@ public class PaymentResponseDto {
 
     private String paymentKey;
 
-    private String paymentStatus;
+    private PaymentStatus paymentStatus;
 
     private LocalDateTime requestedAt;
 

--- a/src/main/java/store/ckin/api/payment/entity/Payment.java
+++ b/src/main/java/store/ckin/api/payment/entity/Payment.java
@@ -3,6 +3,8 @@ package store.ckin.api.payment.entity;
 import java.time.LocalDateTime;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -42,7 +44,8 @@ public class Payment {
     private String paymentKey;
 
     @Column(name = "payment_status")
-    private String paymentStatus;
+    @Enumerated(value = EnumType.STRING)
+    private PaymentStatus paymentStatus;
 
     @Column(name = "payment_requested_at")
     private LocalDateTime requestedAt;
@@ -55,7 +58,8 @@ public class Payment {
 
 
     @Builder
-    public Payment(Long paymentId, Sale sale, String paymentKey, String paymentStatus, LocalDateTime requestedAt,
+    public Payment(Long paymentId, Sale sale, String paymentKey,
+                   PaymentStatus paymentStatus, LocalDateTime requestedAt,
                    LocalDateTime approvedAt, String receipt) {
         this.paymentId = paymentId;
         this.sale = sale;
@@ -64,5 +68,9 @@ public class Payment {
         this.requestedAt = requestedAt;
         this.approvedAt = approvedAt;
         this.receipt = receipt;
+    }
+
+    public void cancelPayment() {
+        this.paymentStatus = PaymentStatus.CANCEL;
     }
 }

--- a/src/main/java/store/ckin/api/payment/entity/PaymentStatus.java
+++ b/src/main/java/store/ckin/api/payment/entity/PaymentStatus.java
@@ -1,0 +1,11 @@
+package store.ckin.api.payment.entity;
+
+/**
+ * 결제 상태를 나타내는 enum.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+public enum PaymentStatus {
+    DONE, CANCEL
+}

--- a/src/main/java/store/ckin/api/payment/repository/PaymentRepository.java
+++ b/src/main/java/store/ckin/api/payment/repository/PaymentRepository.java
@@ -1,5 +1,6 @@
 package store.ckin.api.payment.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import store.ckin.api.payment.entity.Payment;
 
@@ -11,4 +12,5 @@ import store.ckin.api.payment.entity.Payment;
  */
 public interface PaymentRepository extends JpaRepository<Payment, Long>, PaymentRepositoryCustom {
 
+    Optional<Payment> findBySale_SaleId(Long saleId);
 }

--- a/src/main/java/store/ckin/api/payment/repository/PaymentRepositoryImpl.java
+++ b/src/main/java/store/ckin/api/payment/repository/PaymentRepositoryImpl.java
@@ -7,7 +7,7 @@ import store.ckin.api.payment.entity.Payment;
 import store.ckin.api.payment.entity.QPayment;
 
 /**
- * {class name}.
+ * 결제 레포지토리 커스텀 구현 클래스. (Querydsl)
  *
  * @author 정승조
  * @version 2024. 03. 12.

--- a/src/main/java/store/ckin/api/payment/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/store/ckin/api/payment/service/impl/PaymentServiceImpl.java
@@ -2,6 +2,7 @@ package store.ckin.api.payment.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import store.ckin.api.payment.dto.request.PaymentRequestDto;
 import store.ckin.api.payment.dto.response.PaymentResponseDto;
@@ -29,7 +30,7 @@ public class PaymentServiceImpl implements PaymentService {
 
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createPayment(Long saleId, PaymentRequestDto requestDto) {
 
         Sale sale = saleRepository.findById(saleId)

--- a/src/main/java/store/ckin/api/pointhistory/entity/PointHistory.java
+++ b/src/main/java/store/ckin/api/pointhistory/entity/PointHistory.java
@@ -9,12 +9,14 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import store.ckin.api.member.entity.Member;
+import store.ckin.api.sale.entity.Sale;
 
 /**
  * 포인트 내역 엔티티입니다.
@@ -35,6 +37,10 @@ public class PointHistory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "pointhistory_id")
     private Long pointHistoryId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sale_id")
+    private Sale sale;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")

--- a/src/main/java/store/ckin/api/pointhistory/exception/PointHistoryNotFoundException.java
+++ b/src/main/java/store/ckin/api/pointhistory/exception/PointHistoryNotFoundException.java
@@ -1,0 +1,14 @@
+package store.ckin.api.pointhistory.exception;
+
+/**
+ * 포인트 내역을 찾을 수 없을 때 발생하는 예외입니다.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+
+public class PointHistoryNotFoundException extends RuntimeException {
+    public PointHistoryNotFoundException() {
+        super("포인트 내역을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/store/ckin/api/pointhistory/repository/PointHistoryRepository.java
+++ b/src/main/java/store/ckin/api/pointhistory/repository/PointHistoryRepository.java
@@ -1,5 +1,6 @@
 package store.ckin.api.pointhistory.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import store.ckin.api.pointhistory.entity.PointHistory;
 
@@ -10,4 +11,6 @@ import store.ckin.api.pointhistory.entity.PointHistory;
  * @version 2024. 03. 15.
  */
 public interface PointHistoryRepository extends JpaRepository<PointHistory, Long>, PointHistoryRepositoryCustom {
+
+    Optional<PointHistory> findBySale_SaleId(Long saleId);
 }

--- a/src/main/java/store/ckin/api/sale/controller/SaleController.java
+++ b/src/main/java/store/ckin/api/sale/controller/SaleController.java
@@ -3,7 +3,6 @@ package store.ckin.api.sale.controller;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -32,7 +31,6 @@ import store.ckin.api.sale.facade.SaleFacade;
  * @version 2024. 03. 02.
  */
 
-@Slf4j
 @RestController
 @RequestMapping("/api/sales")
 @RequiredArgsConstructor

--- a/src/main/java/store/ckin/api/sale/controller/SaleController.java
+++ b/src/main/java/store/ckin/api/sale/controller/SaleController.java
@@ -154,8 +154,6 @@ public class SaleController {
                                                      @Valid @RequestBody
                                                      SaleDeliveryUpdateRequestDto deliveryStatus) {
 
-        log.info("saleId = {}, deliveryStatus = {}", saleId, deliveryStatus);
-
         saleFacade.updateSaleDeliveryStatus(saleId, deliveryStatus);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/store/ckin/api/sale/controller/SaleController.java
+++ b/src/main/java/store/ckin/api/sale/controller/SaleController.java
@@ -3,6 +3,7 @@ package store.ckin.api.sale.controller;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
+import store.ckin.api.sale.dto.request.SaleDeliveryUpdateRequestDto;
 import store.ckin.api.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
@@ -30,6 +32,7 @@ import store.ckin.api.sale.facade.SaleFacade;
  * @version 2024. 03. 02.
  */
 
+@Slf4j
 @RestController
 @RequestMapping("/api/sales")
 @RequiredArgsConstructor
@@ -71,19 +74,6 @@ public class SaleController {
     public ResponseEntity<SaleDetailResponseDto> getSaleDetail(@PathVariable("saleId") Long saleId) {
 
         return ResponseEntity.ok(saleFacade.getSaleDetail(saleId));
-    }
-
-    /**
-     * 주문 결제 상태를 결제 완료(PAID)로 변경하는 메서드입니다.
-     * 주문의 상태를 업데이트하고, 책 주문의 상태를 완료(COMPLETE)로 업데이트합니다.
-     *
-     * @param saleId 주문 ID
-     * @return 200 (OK)
-     */
-    @PutMapping("/{saleId}")
-    public ResponseEntity<Void> updateSalePaymentPaidStatus(@PathVariable("saleId") Long saleId) {
-        saleFacade.updateSalePaymentPaidStatus(saleId);
-        return ResponseEntity.ok().build();
     }
 
     /**
@@ -134,7 +124,6 @@ public class SaleController {
             @RequestParam("saleNumber") String saleNumber,
             @RequestParam("memberId") Long memberId) {
 
-
         return ResponseEntity.ok(saleFacade.getMemberSaleDetailBySaleNumber(saleNumber, memberId));
     }
 
@@ -151,5 +140,35 @@ public class SaleController {
             @PageableDefault Pageable pageable) {
 
         return ResponseEntity.ok(saleFacade.getSalesByMemberId(memberId, pageable));
+    }
+
+    /**
+     * 주문 배송 상태를 업데이트하는 메서드입니다.
+     *
+     * @param saleId         주문 ID
+     * @param deliveryStatus 배송 상태
+     * @return 200 (OK)
+     */
+    @PutMapping("/{saleId}/delivery/status")
+    public ResponseEntity<Void> updateDeliveryStatus(@PathVariable Long saleId,
+                                                     @Valid @RequestBody
+                                                     SaleDeliveryUpdateRequestDto deliveryStatus) {
+
+        log.info("saleId = {}, deliveryStatus = {}", saleId, deliveryStatus);
+
+        saleFacade.updateSaleDeliveryStatus(saleId, deliveryStatus);
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 주문 상태를 취소로 변경하는 메서드입니다.
+     *
+     * @param saleId 주문 ID
+     * @return 200 (OK)
+     */
+    @PutMapping("/{saleId}/cancel")
+    public ResponseEntity<Void> cancelSale(@PathVariable Long saleId) {
+        saleFacade.cancelSale(saleId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/store/ckin/api/sale/dto/request/SaleDeliveryUpdateRequestDto.java
+++ b/src/main/java/store/ckin/api/sale/dto/request/SaleDeliveryUpdateRequestDto.java
@@ -1,0 +1,22 @@
+package store.ckin.api.sale.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import store.ckin.api.sale.entity.DeliveryStatus;
+
+/**
+ * 배송 상태 변경 요청 DTO.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+
+@Getter
+@NoArgsConstructor
+public class SaleDeliveryUpdateRequestDto {
+
+
+    @NotNull(message = "유효한 배송 상태를 입력해주세요.")
+    private DeliveryStatus deliveryStatus;
+}

--- a/src/main/java/store/ckin/api/sale/dto/response/SaleResponseDto.java
+++ b/src/main/java/store/ckin/api/sale/dto/response/SaleResponseDto.java
@@ -5,7 +5,8 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.ToString;
+import store.ckin.api.sale.entity.DeliveryStatus;
+import store.ckin.api.sale.entity.SalePaymentStatus;
 import store.ckin.api.sale.entity.Sale;
 
 /**
@@ -45,7 +46,7 @@ public class SaleResponseDto {
 
     private LocalDate saleDeliveryDate;
 
-    private Sale.DeliveryStatus saleDeliveryStatus;
+    private DeliveryStatus saleDeliveryStatus;
 
     private Integer saleDeliveryFee;
 
@@ -53,7 +54,7 @@ public class SaleResponseDto {
 
     private Integer saleTotalPrice;
 
-    private Sale.PaymentStatus salePaymentStatus;
+    private SalePaymentStatus salePaymentStatus;
 
     private String saleShippingPostCode;
 

--- a/src/main/java/store/ckin/api/sale/entity/DeliveryStatus.java
+++ b/src/main/java/store/ckin/api/sale/entity/DeliveryStatus.java
@@ -1,0 +1,11 @@
+package store.ckin.api.sale.entity;
+
+/**
+ * 주문의 배송 상태를 나타내는 Enum.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+public enum DeliveryStatus {
+    READY, IN_PROGRESS, DONE
+}

--- a/src/main/java/store/ckin/api/sale/entity/Sale.java
+++ b/src/main/java/store/ckin/api/sale/entity/Sale.java
@@ -16,6 +16,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,23 +33,10 @@ import store.ckin.api.member.entity.Member;
 @Getter
 @Entity
 @Table(name = "Sale")
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Sale {
-
-
-    /**
-     * 주문의 배송 상태를 나타내는 Enum.
-     */
-    public enum DeliveryStatus {
-        READY, IN_PROGRESS, DONE
-    }
-
-    /**
-     * 주문의 결제 상태를 나타내는 Enum.
-     */
-    public enum PaymentStatus {
-        WAITING, PAID
-    }
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -107,40 +95,16 @@ public class Sale {
 
     @Column(name = "sale_payment_status")
     @Enumerated(EnumType.STRING)
-    private PaymentStatus salePaymentStatus;
+    private SalePaymentStatus salePaymentStatus;
 
     @Column(name = "sale_shipping_post_code")
     private String saleShippingPostCode;
 
-    @Builder
-    public Sale(Long saleId, Member member, Set<BookSale> bookSales, String saleTitle, String saleNumber,
-                String saleOrdererName, String saleOrdererContact, String saleReceiverName, String saleReceiverContact,
-                String saleReceiverAddress, LocalDateTime saleDate, LocalDateTime saleShippingDate,
-                LocalDate saleDeliveryDate, DeliveryStatus saleDeliveryStatus, Integer saleDeliveryFee,
-                Integer salePointUsage, Integer saleTotalPrice, PaymentStatus salePaymentStatus,
-                String saleShippingPostCode) {
-        this.saleId = saleId;
-        this.member = member;
-        this.bookSales = bookSales;
-        this.saleTitle = saleTitle;
-        this.saleNumber = saleNumber;
-        this.saleOrdererName = saleOrdererName;
-        this.saleOrdererContact = saleOrdererContact;
-        this.saleReceiverName = saleReceiverName;
-        this.saleReceiverContact = saleReceiverContact;
-        this.saleReceiverAddress = saleReceiverAddress;
-        this.saleDate = saleDate;
-        this.saleShippingDate = saleShippingDate;
-        this.saleDeliveryDate = saleDeliveryDate;
-        this.saleDeliveryStatus = saleDeliveryStatus;
-        this.saleDeliveryFee = saleDeliveryFee;
-        this.salePointUsage = salePointUsage;
-        this.saleTotalPrice = saleTotalPrice;
-        this.salePaymentStatus = salePaymentStatus;
-        this.saleShippingPostCode = saleShippingPostCode;
+    public void updatePaymentStatus(SalePaymentStatus paymentStatus) {
+        this.salePaymentStatus = paymentStatus;
     }
 
-    public void updatePaymentStatus(PaymentStatus paymentStatus) {
-        this.salePaymentStatus = paymentStatus;
+    public void updateSaleDeliveryStatus(DeliveryStatus deliveryStatus) {
+        this.saleDeliveryStatus = deliveryStatus;
     }
 }

--- a/src/main/java/store/ckin/api/sale/entity/SalePaymentStatus.java
+++ b/src/main/java/store/ckin/api/sale/entity/SalePaymentStatus.java
@@ -1,0 +1,11 @@
+package store.ckin.api.sale.entity;
+
+/**
+ * 주문의 결제 상태를 나타내는 Enum.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+public enum SalePaymentStatus {
+    WAITING, PAID, CANCEL
+}

--- a/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
+++ b/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
@@ -53,6 +53,7 @@ public class SaleFacade {
      * @param requestDto 주문 생성 요청 DTO
      * @return 생성된 주문 ID
      */
+    @Transactional
     public String createSale(SaleCreateRequestDto requestDto) {
 
         SaleResponseDto sale = saleService.createSale(requestDto.toCreateSaleWithoutBookRequestDto());

--- a/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
+++ b/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
@@ -96,8 +96,6 @@ public class SaleFacade {
 
         List<BookAndBookSaleResponseDto> bookSale = bookSaleService.getBookSaleDetail(saleId);
 
-        log.info("bookSale = {}", bookSale);
-
         SaleResponseDto saleDetail = saleService.getSaleDetail(saleId);
         PaymentResponseDto payment = paymentService.getPayment(saleId);
 

--- a/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
+++ b/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import store.ckin.api.booksale.dto.response.BookAndBookSaleResponseDto;
-import store.ckin.api.booksale.entity.BookSale;
 import store.ckin.api.booksale.service.BookSaleService;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.member.service.MemberService;
@@ -17,6 +16,7 @@ import store.ckin.api.payment.service.PaymentService;
 import store.ckin.api.pointhistory.dto.request.PointHistoryCreateRequestDto;
 import store.ckin.api.pointhistory.service.PointHistoryService;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
+import store.ckin.api.sale.dto.request.SaleDeliveryUpdateRequestDto;
 import store.ckin.api.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
@@ -53,7 +53,6 @@ public class SaleFacade {
      * @param requestDto 주문 생성 요청 DTO
      * @return 생성된 주문 ID
      */
-    @Transactional
     public String createSale(SaleCreateRequestDto requestDto) {
 
         SaleResponseDto sale = saleService.createSale(requestDto.toCreateSaleWithoutBookRequestDto());
@@ -104,18 +103,6 @@ public class SaleFacade {
 
 
         return new SaleDetailResponseDto(bookSale, saleDetail, payment);
-    }
-
-    /**
-     * 주문의 결제 상태를 결제 완료(PAID)로 업데이트하는 메서드입니다.
-     * 주문의 상태를 업데이트하고, 책 주문의 상태를 완료(COMPLETE)로 업데이트합니다.
-     *
-     * @param saleId 주문 ID
-     */
-    @Transactional
-    public void updateSalePaymentPaidStatus(Long saleId) {
-        bookSaleService.updateBookSaleState(saleId, BookSale.BookSaleState.COMPLETE);
-        saleService.updateSalePaymentPaidStatus(saleId);
     }
 
     /**
@@ -172,7 +159,7 @@ public class SaleFacade {
     public SaleDetailResponseDto getMemberSaleDetailBySaleNumber(String saleNumber, Long memberId) {
 
         SaleResponseDto saleDetail = saleService.getSaleBySaleNumber(saleNumber);
-      
+
         if (!Objects.equals(memberId, saleDetail.getMemberId())) {
             throw new SaleMemberNotMatchException(saleNumber);
         }
@@ -222,5 +209,33 @@ public class SaleFacade {
     @Transactional(readOnly = true)
     public PagedResponse<List<SaleInfoResponseDto>> getSalesByMemberId(Long memberId, Pageable pageable) {
         return saleService.getSalesByMemberId(memberId, pageable);
+    }
+
+    /**
+     * 주문 배송 상태를 업데이트하는 메서드입니다.
+     *
+     * @param saleId         주문 ID
+     * @param deliveryStatus 배송 상태
+     */
+    @Transactional
+    public void updateSaleDeliveryStatus(Long saleId, SaleDeliveryUpdateRequestDto deliveryStatus) {
+        saleService.updateSaleDeliveryStatus(saleId, deliveryStatus);
+    }
+
+    /**
+     * 주문을 취소하는 메서드입니다.
+     *
+     * @param saleId 주문 ID
+     */
+    @Transactional
+    public void cancelSale(Long saleId) {
+        // 주문 및 결제 상태 변경
+        saleService.cancelSale(saleId);
+
+        // 회원 포인트 변경 및 포인트 이력 생성
+        SaleResponseDto saleDetail = saleService.getSaleDetail(saleId);
+        if (Objects.nonNull(saleDetail.getMemberEmail()) && saleDetail.getSalePointUsage() > 0) {
+            memberService.updateCancelSalePoint(saleId, saleDetail.getMemberEmail());
+        }
     }
 }

--- a/src/main/java/store/ckin/api/sale/service/SaleService.java
+++ b/src/main/java/store/ckin/api/sale/service/SaleService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.sale.dto.request.SaleCreateNoBookRequestDto;
+import store.ckin.api.sale.dto.request.SaleDeliveryUpdateRequestDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
@@ -82,4 +83,20 @@ public interface SaleService {
      * @return 페이징 처리된 주문 응답 DTO 리스트
      */
     PagedResponse<List<SaleInfoResponseDto>> getSalesByMemberId(Long memberId, Pageable pageable);
+
+    /**
+     * 주문 배송 상태를 업데이트합니다.
+     *
+     * @param saleId         주문 ID
+     * @param deliveryStatus 배송 상태
+     */
+    void updateSaleDeliveryStatus(Long saleId, SaleDeliveryUpdateRequestDto deliveryStatus);
+
+    /**
+     * 주문을 취소 상태로 변경합니다.
+     *
+     * @param saleId 주문 ID
+     */
+    void cancelSale(Long saleId);
+
 }

--- a/src/test/java/store/ckin/api/booksale/service/impl/BookSaleServiceImplTest.java
+++ b/src/test/java/store/ckin/api/booksale/service/impl/BookSaleServiceImplTest.java
@@ -207,12 +207,12 @@ class BookSaleServiceImplTest {
         given(bookSaleRepository.findAllByPkSaleId(anyLong()))
                 .willReturn(bookSaleList);
 
-        bookSaleService.updateBookSaleState(1L, BookSale.BookSaleState.COMPLETE);
+        bookSaleService.updateBookSaleState(1L, BookSale.BookSaleState.ORDER);
 
         verify(bookSaleRepository, times(1)).findAllByPkSaleId(anyLong());
 
-        assertEquals(BookSale.BookSaleState.COMPLETE, firstBookSale.getBookSaleState());
-        assertEquals(BookSale.BookSaleState.COMPLETE, secondBookSale.getBookSaleState());
+        assertEquals(BookSale.BookSaleState.ORDER, firstBookSale.getBookSaleState());
+        assertEquals(BookSale.BookSaleState.ORDER, secondBookSale.getBookSaleState());
     }
 
     @Test

--- a/src/test/java/store/ckin/api/payment/controller/PaymentControllerTest.java
+++ b/src/test/java/store/ckin/api/payment/controller/PaymentControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import store.ckin.api.payment.dto.request.PaymentRequestDto;
 import store.ckin.api.payment.dto.response.PaymentSuccessResponseDto;
+import store.ckin.api.payment.entity.PaymentStatus;
 import store.ckin.api.payment.facade.PaymentFacade;
 
 /**
@@ -53,7 +54,7 @@ class PaymentControllerTest {
         PaymentRequestDto paymentRequestDto = new PaymentRequestDto();
         ReflectionTestUtils.setField(paymentRequestDto, "paymentKey", "12341234");
         ReflectionTestUtils.setField(paymentRequestDto, "saleNumber", "423421432");
-        ReflectionTestUtils.setField(paymentRequestDto, "paymentStatus", "DONE");
+        ReflectionTestUtils.setField(paymentRequestDto, "paymentStatus", PaymentStatus.DONE);
         ReflectionTestUtils.setField(paymentRequestDto, "requestedAt", LocalDateTime.now().minusMinutes(10));
         ReflectionTestUtils.setField(paymentRequestDto, "approvedAt", LocalDateTime.now());
         ReflectionTestUtils.setField(paymentRequestDto, "amount", 15000);

--- a/src/test/java/store/ckin/api/payment/facade/PaymentFacadeTest.java
+++ b/src/test/java/store/ckin/api/payment/facade/PaymentFacadeTest.java
@@ -1,7 +1,6 @@
 package store.ckin.api.payment.facade;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.anyString;
@@ -21,11 +20,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import store.ckin.api.member.service.MemberService;
 import store.ckin.api.payment.dto.request.PaymentRequestDto;
+import store.ckin.api.payment.entity.PaymentStatus;
 import store.ckin.api.payment.exception.PaymentAmountNotCorrectException;
 import store.ckin.api.payment.exception.PaymentNotCompleteException;
 import store.ckin.api.payment.service.PaymentService;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
-import store.ckin.api.sale.entity.Sale;
+import store.ckin.api.sale.entity.DeliveryStatus;
+import store.ckin.api.sale.entity.SalePaymentStatus;
 import store.ckin.api.sale.service.SaleService;
 
 /**
@@ -60,7 +61,7 @@ class PaymentFacadeTest {
         failPayment = new PaymentRequestDto();
         ReflectionTestUtils.setField(failPayment, "paymentKey", "12341234");
         ReflectionTestUtils.setField(failPayment, "saleNumber", "423421432");
-        ReflectionTestUtils.setField(failPayment, "paymentStatus", "FAIL");
+        ReflectionTestUtils.setField(failPayment, "paymentStatus", PaymentStatus.CANCEL);
         ReflectionTestUtils.setField(failPayment, "requestedAt", LocalDateTime.now().minusMinutes(10));
         ReflectionTestUtils.setField(failPayment, "approvedAt", LocalDateTime.now());
         ReflectionTestUtils.setField(failPayment, "amount", 15000);
@@ -69,7 +70,7 @@ class PaymentFacadeTest {
         successPayment = new PaymentRequestDto();
         ReflectionTestUtils.setField(successPayment, "paymentKey", "12341234");
         ReflectionTestUtils.setField(successPayment, "saleNumber", "423421432");
-        ReflectionTestUtils.setField(successPayment, "paymentStatus", "DONE");
+        ReflectionTestUtils.setField(successPayment, "paymentStatus", PaymentStatus.DONE);
         ReflectionTestUtils.setField(successPayment, "requestedAt", LocalDateTime.now().minusMinutes(10));
         ReflectionTestUtils.setField(successPayment, "approvedAt", LocalDateTime.now());
         ReflectionTestUtils.setField(successPayment, "amount", 15000);
@@ -109,11 +110,11 @@ class PaymentFacadeTest {
                         LocalDateTime.now(),
                         LocalDateTime.now().plusDays(1),
                         LocalDate.now().plusDays(3),
-                        Sale.DeliveryStatus.READY,
+                        DeliveryStatus.READY,
                         3000,
                         0,
                         10000,
-                        Sale.PaymentStatus.WAITING,
+                        SalePaymentStatus.WAITING,
                         "123456"
                 );
 
@@ -148,11 +149,11 @@ class PaymentFacadeTest {
                         LocalDateTime.now(),
                         LocalDateTime.now().plusDays(1),
                         LocalDate.now().plusDays(3),
-                        Sale.DeliveryStatus.READY,
+                        DeliveryStatus.READY,
                         3000,
                         0,
                         15000,
-                        Sale.PaymentStatus.WAITING,
+                        SalePaymentStatus.WAITING,
                         "123456"
                 );
 
@@ -163,76 +164,5 @@ class PaymentFacadeTest {
 
         verify(saleService, times(1)).getSaleBySaleNumber(anyString());
         verify(paymentService, times(1)).createPayment(anyLong(), any());
-    }
-
-    @Test
-    @DisplayName("포인트 적립 테스트 - 회원일 경우")
-    void testCreateRewardPoint_Member() {
-        SaleResponseDto saleResponseDto =
-                new SaleResponseDto(
-                        1L,
-                        1L,
-                        "테스트 제목",
-                        "test@test.com",
-                        "1234",
-                        "정승조",
-                        "01012345678",
-                        "정승조",
-                        "01012345678",
-                        "광주광역시 동구 조선대 5길",
-                        LocalDateTime.now(),
-                        LocalDateTime.now().plusDays(1),
-                        LocalDate.now().plusDays(3),
-                        Sale.DeliveryStatus.READY,
-                        3000,
-                        0,
-                        15000,
-                        Sale.PaymentStatus.WAITING,
-                        "123456"
-                );
-
-        given(saleService.getSaleBySaleNumber(anyString()))
-                .willReturn(saleResponseDto);
-
-        paymentFacade.createRewardPoint("123456");
-
-        verify(saleService, times(1)).getSaleBySaleNumber(anyString());
-        verify(memberService, times(1)).updateRewardPoint(anyString(), anyInt());
-    }
-
-    @Test
-    @DisplayName("포인트 적립 테스트 - 비회원일 경우")
-    void testCreateRewardPoint_Anonymous() {
-        SaleResponseDto saleResponseDto =
-                new SaleResponseDto(
-                        1L,
-                        1L,
-                        "테스트 제목",
-                        null,
-                        "123456",
-                        "정승조",
-                        "01012345678",
-                        "정승조",
-                        "01012345678",
-                        "광주광역시 동구 조선대 5길",
-                        LocalDateTime.now(),
-                        LocalDateTime.now().plusDays(1),
-                        LocalDate.now().plusDays(3),
-                        Sale.DeliveryStatus.READY,
-                        3000,
-                        0,
-                        15000,
-                        Sale.PaymentStatus.WAITING,
-                        "123456"
-                );
-
-
-        given(saleService.getSaleBySaleNumber(anyString()))
-                .willReturn(saleResponseDto);
-
-        paymentFacade.createRewardPoint("123456");
-
-        verify(saleService, times(1)).getSaleBySaleNumber(anyString());
-        verify(memberService, times(0)).updateRewardPoint(anyString(), anyInt());
     }
 }

--- a/src/test/java/store/ckin/api/payment/repository/PaymentRepositoryTest.java
+++ b/src/test/java/store/ckin/api/payment/repository/PaymentRepositoryTest.java
@@ -48,7 +48,6 @@ class PaymentRepositoryTest {
     Book book;
 
     Sale sale;
-    DeliveryStatus DeliveryStatus;
 
     @BeforeEach
     void setUp() {

--- a/src/test/java/store/ckin/api/payment/repository/PaymentRepositoryTest.java
+++ b/src/test/java/store/ckin/api/payment/repository/PaymentRepositoryTest.java
@@ -18,7 +18,10 @@ import store.ckin.api.grade.entity.Grade;
 import store.ckin.api.member.entity.Member;
 import store.ckin.api.payment.dto.response.PaymentResponseDto;
 import store.ckin.api.payment.entity.Payment;
+import store.ckin.api.payment.entity.PaymentStatus;
+import store.ckin.api.sale.entity.DeliveryStatus;
 import store.ckin.api.sale.entity.Sale;
+import store.ckin.api.sale.entity.SalePaymentStatus;
 
 /**
  * 결제 레포지토리 테스트입니다.
@@ -45,6 +48,7 @@ class PaymentRepositoryTest {
     Book book;
 
     Sale sale;
+    DeliveryStatus DeliveryStatus;
 
     @BeforeEach
     void setUp() {
@@ -102,10 +106,10 @@ class PaymentRepositoryTest {
                 .saleDate(LocalDateTime.now())
                 .saleShippingDate(LocalDateTime.now())
                 .saleDeliveryDate(LocalDate.now().plusDays(2))
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryStatus(DeliveryStatus.READY)
                 .saleDeliveryFee(3000)
                 .salePointUsage(1000)
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .salePaymentStatus(SalePaymentStatus.WAITING)
                 .saleShippingPostCode("123456")
                 .build();
 
@@ -120,7 +124,7 @@ class PaymentRepositoryTest {
         Payment payment = Payment.builder()
                 .sale(sale)
                 .paymentKey("12343214")
-                .paymentStatus("DONE")
+                .paymentStatus(PaymentStatus.DONE)
                 .requestedAt(LocalDateTime.now().minusMinutes(10))
                 .approvedAt(LocalDateTime.now())
                 .receipt("https://test.com")
@@ -145,7 +149,7 @@ class PaymentRepositoryTest {
         Payment payment = Payment.builder()
                 .sale(sale)
                 .paymentKey("12343214")
-                .paymentStatus("DONE")
+                .paymentStatus(PaymentStatus.DONE)
                 .requestedAt(LocalDateTime.now().minusMinutes(10))
                 .approvedAt(LocalDateTime.now())
                 .receipt("https://test.com")

--- a/src/test/java/store/ckin/api/payment/service/impl/PaymentServiceImplTest.java
+++ b/src/test/java/store/ckin/api/payment/service/impl/PaymentServiceImplTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import store.ckin.api.payment.dto.request.PaymentRequestDto;
+import store.ckin.api.payment.entity.PaymentStatus;
 import store.ckin.api.payment.repository.PaymentRepository;
 import store.ckin.api.sale.entity.Sale;
 import store.ckin.api.sale.exception.SaleNotFoundException;
@@ -47,7 +48,7 @@ class PaymentServiceImplTest {
         PaymentRequestDto paymentRequestDto = new PaymentRequestDto();
         ReflectionTestUtils.setField(paymentRequestDto, "paymentKey", "12341234");
         ReflectionTestUtils.setField(paymentRequestDto, "saleNumber", "423421432");
-        ReflectionTestUtils.setField(paymentRequestDto, "paymentStatus", "DONE");
+        ReflectionTestUtils.setField(paymentRequestDto, "paymentStatus", PaymentStatus.DONE);
         ReflectionTestUtils.setField(paymentRequestDto, "requestedAt", LocalDateTime.now().minusMinutes(10));
         ReflectionTestUtils.setField(paymentRequestDto, "approvedAt", LocalDateTime.now());
         ReflectionTestUtils.setField(paymentRequestDto, "amount", 15000);
@@ -70,12 +71,11 @@ class PaymentServiceImplTest {
         PaymentRequestDto paymentRequestDto = new PaymentRequestDto();
         ReflectionTestUtils.setField(paymentRequestDto, "paymentKey", "12341234");
         ReflectionTestUtils.setField(paymentRequestDto, "saleNumber", "423421432");
-        ReflectionTestUtils.setField(paymentRequestDto, "paymentStatus", "DONE");
+        ReflectionTestUtils.setField(paymentRequestDto, "paymentStatus", PaymentStatus.DONE);
         ReflectionTestUtils.setField(paymentRequestDto, "requestedAt", LocalDateTime.now().minusMinutes(10));
         ReflectionTestUtils.setField(paymentRequestDto, "approvedAt", LocalDateTime.now());
         ReflectionTestUtils.setField(paymentRequestDto, "amount", 15000);
         ReflectionTestUtils.setField(paymentRequestDto, "receiptUrl", "https://test.com");
-
 
 
         given(saleRepository.findById(anyLong()))

--- a/src/test/java/store/ckin/api/sale/controller/SaleControllerTest.java
+++ b/src/test/java/store/ckin/api/sale/controller/SaleControllerTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -31,12 +30,14 @@ import store.ckin.api.booksale.dto.response.BookAndBookSaleResponseDto;
 import store.ckin.api.common.domain.PageInfo;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.payment.dto.response.PaymentResponseDto;
+import store.ckin.api.payment.entity.PaymentStatus;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
 import store.ckin.api.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
-import store.ckin.api.sale.entity.Sale;
+import store.ckin.api.sale.entity.DeliveryStatus;
+import store.ckin.api.sale.entity.SalePaymentStatus;
 import store.ckin.api.sale.facade.SaleFacade;
 
 /**
@@ -109,11 +110,11 @@ class SaleControllerTest {
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0),
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0).plusDays(1),
                         LocalDate.of(2024, 3, 7).plusDays(3),
-                        Sale.DeliveryStatus.READY,
+                        DeliveryStatus.READY,
                         3000,
                         0,
                         10000,
-                        Sale.PaymentStatus.WAITING,
+                        SalePaymentStatus.WAITING,
                         "123456"
                 );
 
@@ -170,11 +171,11 @@ class SaleControllerTest {
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0),
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0).plusDays(1),
                         LocalDate.of(2024, 3, 7).plusDays(3),
-                        Sale.DeliveryStatus.READY,
+                        DeliveryStatus.READY,
                         3000,
                         0,
                         10000,
-                        Sale.PaymentStatus.WAITING,
+                        SalePaymentStatus.WAITING,
                         "123456"
                 );
 
@@ -182,7 +183,7 @@ class SaleControllerTest {
                 1L,
                 1L,
                 "1232321",
-                "1234",
+                PaymentStatus.DONE,
                 LocalDateTime.now(),
                 LocalDateTime.now().plusHours(1),
                 "test.com");
@@ -237,7 +238,7 @@ class SaleControllerTest {
                         jsonPath("$.paymentResponseDto.paymentId").value(payment.getPaymentId()),
                         jsonPath("$.paymentResponseDto.saleId").value(payment.getSaleId()),
                         jsonPath("$.paymentResponseDto.paymentKey").value(payment.getPaymentKey()),
-                        jsonPath("$.paymentResponseDto.paymentStatus").value(payment.getPaymentStatus()),
+                        jsonPath("$.paymentResponseDto.paymentStatus").value(payment.getPaymentStatus().name()),
                         jsonPath("$.paymentResponseDto.requestedAt").isNotEmpty(),
                         jsonPath("$.paymentResponseDto.approvedAt").isNotEmpty(),
                         jsonPath("paymentResponseDto.receiptUrl").value(payment.getReceiptUrl())
@@ -247,16 +248,6 @@ class SaleControllerTest {
         verify(saleFacade, times(1)).getSaleDetail(anyLong());
     }
 
-    @Test
-    @DisplayName("주문 결제 상태를 완료(PAID)로 변경 테스트")
-    void testUpdateSalePaymentPaidStatus() throws Exception {
-
-        mockMvc.perform(put("/api/sales/{saleId}", 1L))
-                .andExpect(status().isOk())
-                .andDo(print());
-
-        verify(saleFacade, times(1)).updateSalePaymentPaidStatus(1L);
-    }
 
     @Test
     @DisplayName("주문 ID로 주문 상세 정보와 주문한 책 정보 조회 테스트")
@@ -369,11 +360,11 @@ class SaleControllerTest {
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0),
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0).plusDays(1),
                         LocalDate.of(2024, 3, 7).plusDays(3),
-                        Sale.DeliveryStatus.READY,
+                        DeliveryStatus.READY,
                         3000,
                         0,
                         10000,
-                        Sale.PaymentStatus.WAITING,
+                        SalePaymentStatus.WAITING,
                         "123456"
                 );
 
@@ -382,7 +373,7 @@ class SaleControllerTest {
                 1L,
                 1L,
                 "1232321",
-                "1234",
+                PaymentStatus.DONE,
                 LocalDateTime.now(),
                 LocalDateTime.now().plusHours(1),
                 "test.com");
@@ -428,7 +419,7 @@ class SaleControllerTest {
                         jsonPath("$.paymentResponseDto.paymentId").value(payment.getPaymentId()),
                         jsonPath("$.paymentResponseDto.saleId").value(payment.getSaleId()),
                         jsonPath("$.paymentResponseDto.paymentKey").value(payment.getPaymentKey()),
-                        jsonPath("$.paymentResponseDto.paymentStatus").value(payment.getPaymentStatus()),
+                        jsonPath("$.paymentResponseDto.paymentStatus").value(payment.getPaymentStatus().name()),
                         jsonPath("$.paymentResponseDto.requestedAt").isNotEmpty(),
                         jsonPath("$.paymentResponseDto.approvedAt").isNotEmpty(),
                         jsonPath("paymentResponseDto.receiptUrl").value(payment.getReceiptUrl())
@@ -465,11 +456,11 @@ class SaleControllerTest {
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0),
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0).plusDays(1),
                         LocalDate.of(2024, 3, 7).plusDays(3),
-                        Sale.DeliveryStatus.READY,
+                        DeliveryStatus.READY,
                         3000,
                         0,
                         10000,
-                        Sale.PaymentStatus.WAITING,
+                        SalePaymentStatus.WAITING,
                         "123456"
                 );
 
@@ -477,7 +468,7 @@ class SaleControllerTest {
                 1L,
                 1L,
                 "1232321",
-                "1234",
+                PaymentStatus.DONE,
                 LocalDateTime.now(),
                 LocalDateTime.now().plusHours(1),
                 "test.com");
@@ -523,7 +514,7 @@ class SaleControllerTest {
                         jsonPath("$.paymentResponseDto.paymentId").value(payment.getPaymentId()),
                         jsonPath("$.paymentResponseDto.saleId").value(payment.getSaleId()),
                         jsonPath("$.paymentResponseDto.paymentKey").value(payment.getPaymentKey()),
-                        jsonPath("$.paymentResponseDto.paymentStatus").value(payment.getPaymentStatus()),
+                        jsonPath("$.paymentResponseDto.paymentStatus").value(payment.getPaymentStatus().name()),
                         jsonPath("$.paymentResponseDto.requestedAt").isNotEmpty(),
                         jsonPath("$.paymentResponseDto.approvedAt").isNotEmpty(),
                         jsonPath("paymentResponseDto.receiptUrl").value(payment.getReceiptUrl())

--- a/src/test/java/store/ckin/api/sale/facade/SaleFacadeTest.java
+++ b/src/test/java/store/ckin/api/sale/facade/SaleFacadeTest.java
@@ -28,13 +28,15 @@ import store.ckin.api.booksale.entity.BookSale;
 import store.ckin.api.booksale.service.BookSaleService;
 import store.ckin.api.member.service.MemberService;
 import store.ckin.api.payment.dto.response.PaymentResponseDto;
+import store.ckin.api.payment.entity.PaymentStatus;
 import store.ckin.api.payment.service.PaymentService;
 import store.ckin.api.pointhistory.service.PointHistoryService;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
 import store.ckin.api.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
-import store.ckin.api.sale.entity.Sale;
+import store.ckin.api.sale.entity.DeliveryStatus;
+import store.ckin.api.sale.entity.SalePaymentStatus;
 import store.ckin.api.sale.exception.SaleOrdererContactNotMatchException;
 import store.ckin.api.sale.service.SaleService;
 
@@ -122,11 +124,11 @@ class SaleFacadeTest {
                         LocalDateTime.now(),
                         LocalDateTime.now().plusDays(1),
                         LocalDate.now().plusDays(3),
-                        Sale.DeliveryStatus.READY,
+                        DeliveryStatus.READY,
                         3000,
                         0,
                         10000,
-                        Sale.PaymentStatus.WAITING,
+                        SalePaymentStatus.WAITING,
                         "123456"
                 );
 
@@ -186,11 +188,11 @@ class SaleFacadeTest {
                         LocalDateTime.now(),
                         LocalDateTime.now().plusDays(1),
                         LocalDate.now().plusDays(3),
-                        Sale.DeliveryStatus.READY,
+                        DeliveryStatus.READY,
                         3000,
                         0,
                         10000,
-                        Sale.PaymentStatus.WAITING,
+                        SalePaymentStatus.WAITING,
                         "123456"
                 );
 
@@ -203,7 +205,7 @@ class SaleFacadeTest {
                         1L,
                         3L,
                         "12421312",
-                        "DONE",
+                        PaymentStatus.DONE,
                         LocalDateTime.now(),
                         LocalDateTime.now().plusMinutes(10),
                         "test.com"
@@ -220,16 +222,6 @@ class SaleFacadeTest {
                 () -> assertEquals(saleDetail.getPaymentResponseDto(), payment));
 
         verify(saleService, times(1)).getSaleDetail(1L);
-    }
-
-    @Test
-    @DisplayName("주문 결제 상태 완료 변경 테스트")
-    void testUpdateSalePaymentPaidStatus() {
-
-        saleFacade.updateSalePaymentPaidStatus(1L);
-
-        verify(bookSaleService, times(1)).updateBookSaleState(1L, BookSale.BookSaleState.COMPLETE);
-        verify(saleService, times(1)).updateSalePaymentPaidStatus(1L);
     }
 
     @Test
@@ -293,11 +285,11 @@ class SaleFacadeTest {
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0),
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0).plusDays(1),
                         LocalDate.of(2024, 3, 7).plusDays(3),
-                        Sale.DeliveryStatus.READY,
+                        DeliveryStatus.READY,
                         3000,
                         0,
                         10000,
-                        Sale.PaymentStatus.WAITING,
+                        SalePaymentStatus.WAITING,
                         "123456"
                 );
 
@@ -326,11 +318,11 @@ class SaleFacadeTest {
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0),
                         LocalDateTime.of(2024, 3, 7, 12, 0, 0).plusDays(1),
                         LocalDate.of(2024, 3, 7).plusDays(3),
-                        Sale.DeliveryStatus.READY,
+                        DeliveryStatus.READY,
                         3000,
                         0,
                         10000,
-                        Sale.PaymentStatus.WAITING,
+                        SalePaymentStatus.WAITING,
                         "123456"
                 );
 

--- a/src/test/java/store/ckin/api/sale/facade/SaleFacadeTest.java
+++ b/src/test/java/store/ckin/api/sale/facade/SaleFacadeTest.java
@@ -24,7 +24,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 import store.ckin.api.booksale.dto.request.BookSaleCreateRequestDto;
 import store.ckin.api.booksale.dto.response.BookAndBookSaleResponseDto;
-import store.ckin.api.booksale.entity.BookSale;
 import store.ckin.api.booksale.service.BookSaleService;
 import store.ckin.api.member.service.MemberService;
 import store.ckin.api.payment.dto.response.PaymentResponseDto;

--- a/src/test/java/store/ckin/api/sale/repository/SaleRepositoryTest.java
+++ b/src/test/java/store/ckin/api/sale/repository/SaleRepositoryTest.java
@@ -25,7 +25,9 @@ import store.ckin.api.member.entity.Member;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
+import store.ckin.api.sale.entity.DeliveryStatus;
 import store.ckin.api.sale.entity.Sale;
+import store.ckin.api.sale.entity.SalePaymentStatus;
 
 /**
  * 주문 레포지토리 테스트.
@@ -117,10 +119,10 @@ class SaleRepositoryTest {
                 .saleDate(LocalDateTime.now())
                 .saleShippingDate(LocalDateTime.now())
                 .saleDeliveryDate(LocalDate.now().plusDays(2))
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryStatus(DeliveryStatus.READY)
                 .saleDeliveryFee(3000)
                 .salePointUsage(1000)
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .salePaymentStatus(SalePaymentStatus.WAITING)
                 .saleShippingPostCode("123456")
                 .build();
 
@@ -162,10 +164,10 @@ class SaleRepositoryTest {
                 .saleDate(LocalDateTime.now())
                 .saleShippingDate(LocalDateTime.now())
                 .saleDeliveryDate(LocalDate.now().plusDays(2))
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryStatus(DeliveryStatus.READY)
                 .saleDeliveryFee(3000)
                 .salePointUsage(1000)
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .salePaymentStatus(SalePaymentStatus.WAITING)
                 .saleShippingPostCode("123456")
                 .build();
 
@@ -184,10 +186,10 @@ class SaleRepositoryTest {
                 .saleDate(LocalDateTime.now())
                 .saleShippingDate(LocalDateTime.now())
                 .saleDeliveryDate(LocalDate.now().plusDays(2))
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryStatus(DeliveryStatus.READY)
                 .saleDeliveryFee(3000)
                 .salePointUsage(1000)
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .salePaymentStatus(SalePaymentStatus.WAITING)
                 .saleShippingPostCode("123456")
                 .build();
 
@@ -214,10 +216,10 @@ class SaleRepositoryTest {
                 .saleDate(LocalDateTime.now())
                 .saleShippingDate(LocalDateTime.now())
                 .saleDeliveryDate(LocalDate.now().plusDays(2))
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryStatus(DeliveryStatus.READY)
                 .saleDeliveryFee(3000)
                 .salePointUsage(1000)
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .salePaymentStatus(SalePaymentStatus.WAITING)
                 .saleShippingPostCode("123456")
                 .build();
 
@@ -259,10 +261,10 @@ class SaleRepositoryTest {
                 .saleDate(LocalDateTime.now())
                 .saleShippingDate(LocalDateTime.now())
                 .saleDeliveryDate(LocalDate.now().plusDays(2))
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryStatus(DeliveryStatus.READY)
                 .saleDeliveryFee(3000)
                 .salePointUsage(1000)
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .salePaymentStatus(SalePaymentStatus.WAITING)
                 .saleShippingPostCode("123456")
                 .build();
 
@@ -320,10 +322,10 @@ class SaleRepositoryTest {
                 .saleDate(LocalDateTime.now())
                 .saleShippingDate(LocalDateTime.now())
                 .saleDeliveryDate(LocalDate.now().plusDays(2))
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryStatus(DeliveryStatus.READY)
                 .saleDeliveryFee(3000)
                 .salePointUsage(1000)
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .salePaymentStatus(SalePaymentStatus.WAITING)
                 .saleShippingPostCode("123456")
                 .build();
 
@@ -366,10 +368,10 @@ class SaleRepositoryTest {
                 .saleDate(LocalDateTime.now())
                 .saleShippingDate(LocalDateTime.now())
                 .saleDeliveryDate(LocalDate.now().plusDays(2))
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryStatus(DeliveryStatus.READY)
                 .saleDeliveryFee(3000)
                 .salePointUsage(1000)
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .salePaymentStatus(SalePaymentStatus.WAITING)
                 .saleShippingPostCode("123456")
                 .build();
 

--- a/src/test/java/store/ckin/api/sale/service/impl/SaleServiceImplTest.java
+++ b/src/test/java/store/ckin/api/sale/service/impl/SaleServiceImplTest.java
@@ -34,7 +34,9 @@ import store.ckin.api.sale.dto.request.SaleCreateNoBookRequestDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
+import store.ckin.api.sale.entity.DeliveryStatus;
 import store.ckin.api.sale.entity.Sale;
+import store.ckin.api.sale.entity.SalePaymentStatus;
 import store.ckin.api.sale.exception.SaleNotFoundException;
 import store.ckin.api.sale.exception.SaleNotFoundExceptionBySaleNumber;
 import store.ckin.api.sale.exception.SaleNumberNotFoundException;
@@ -99,11 +101,11 @@ class SaleServiceImplTest {
                 .saleDate(LocalDateTime.now())
                 .saleShippingDate(LocalDateTime.now())
                 .saleDeliveryDate(LocalDate.now().plusDays(2))
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryStatus(DeliveryStatus.READY)
                 .saleDeliveryFee(3000)
                 .salePointUsage(1000)
                 .saleTotalPrice(10000)
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .salePaymentStatus(SalePaymentStatus.WAITING)
                 .saleShippingPostCode("123456")
                 .build();
     }
@@ -160,11 +162,11 @@ class SaleServiceImplTest {
                 .saleDate(LocalDateTime.now())
                 .saleShippingDate(LocalDateTime.now())
                 .saleDeliveryDate(LocalDate.now().plusDays(2))
-                .saleDeliveryStatus(Sale.DeliveryStatus.READY)
+                .saleDeliveryStatus(DeliveryStatus.READY)
                 .saleDeliveryFee(3000)
                 .salePointUsage(1000)
                 .saleTotalPrice(10000)
-                .salePaymentStatus(Sale.PaymentStatus.WAITING)
+                .salePaymentStatus(SalePaymentStatus.WAITING)
                 .saleShippingPostCode("123456")
                 .build();
 
@@ -232,7 +234,7 @@ class SaleServiceImplTest {
 
         saleService.updateSalePaymentPaidStatus(1L);
 
-        assertEquals(Sale.PaymentStatus.PAID, sale.getSalePaymentStatus());
+        assertEquals(SalePaymentStatus.PAID, sale.getSalePaymentStatus());
     }
 
     @Test
@@ -422,7 +424,6 @@ class SaleServiceImplTest {
 
         PagedResponse<List<SaleInfoResponseDto>> responseDto =
                 saleService.getSalesByMemberId(1L, Pageable.ofSize(10));
-
 
 
         assertAll(


### PR DESCRIPTION
> PR 내용은 Front와 동일합니다.

## #️⃣ 연관된 이슈

#141

## 📝 작업 내용

- [x] 1. 토스 페이먼츠 서버 - 결제 취소 API 호출 (결제가 완료된 주문건만)
- [x] 2. API 서버 - 주문 취소 API 호출

![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/93f6a67b-bb93-4c45-b9cb-1e8a52c6b7c9)

### API 서버
1. 주문의 상태를 CANCEL로 수정

#### 결제를 진행하지 않은 주문 (WAITING)

- 주문할 때 사용한 포인트를 돌려줍니다.
- 포인트 내역에 `주문 취소` 라고 내용을 기재합니다.


#### 결제를 진행한 주문 (PAID)

- **(주문 금액 + 주문할 때 사용한 포인트) - 결제를 하면서 쌓인 적립금**을 계산하여 회원에게 다시 돌려줍니다.
- 포인트 내역에 `주문 취소`라고 내용을 기재합니다.
- 주문이 완료된 결제 금액은 **포인트로 다시 반환**하는 방식으로 진행하였습니다. 

> 주문 금액 : 10,000원
> 주문할 때 사용한 포인트 : 1,770원
> 주문 적립금 : 1,000원 (10%)
> <img width="1470" alt="스크린샷 2024-03-19 오후 9 57 40" src="https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/08f8b712-1002-4b73-8afd-139d2087f894">


## 👀 참고 사항
> 토스 페이먼츠 API는 테스트용이기 때문에 취소를 확인하는 용도로만 사용하였습니다. 
> ![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/2fb4c864-de77-4030-91d7-03e70e4fd706)