### PR TITLE
[FEAT] 주문 - 리뷰를 작성할 수 있는 회원 체크 로직 추가

### DIFF
--- a/src/docs/asciidoc/sale.adoc
+++ b/src/docs/asciidoc/sale.adoc
@@ -164,3 +164,17 @@ include::{snippets}/sale/updateSaleStatus/cancel/http-response.adoc[]
 
 {empty} +
 
+=== 회원 ID와 도서 ID를 통해 주문 여부 확인
+
+==== Request
+include::{snippets}/sale/checkSaleByMemberIdAndBookId/success/http-request.adoc[]
+
+==== Request Path Parameters
+include::{snippets}/sale/checkSaleByMemberIdAndBookId/success/path-parameters.adoc[]
+
+
+==== Response
+include::{snippets}/sale/checkSaleByMemberIdAndBookId/success/http-response.adoc[]
+
+==== Response Fields
+include::{snippets}/sale/checkSaleByMemberIdAndBookId/success/response-fields.adoc[]

--- a/src/main/java/store/ckin/api/sale/controller/SaleController.java
+++ b/src/main/java/store/ckin/api/sale/controller/SaleController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
 import store.ckin.api.sale.dto.request.SaleDeliveryUpdateRequestDto;
+import store.ckin.api.sale.dto.response.SaleCheckResponseDto;
 import store.ckin.api.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
@@ -166,5 +167,19 @@ public class SaleController {
     public ResponseEntity<Void> cancelSale(@PathVariable Long saleId) {
         saleFacade.cancelSale(saleId);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 회원 ID와 도서 ID를 통해 주문 리스트에 해당 주문이 존재하는지 확인하는 메서드입니다.
+     *
+     * @param memberId 회원 ID
+     * @param bookId   도서 ID
+     * @return 200 (OK), 주문 확인 응답 DTO
+     */
+    @GetMapping("/check/{memberId}/{bookId}")
+    public ResponseEntity<SaleCheckResponseDto> checkSaleByMemberIdAndBookId(@PathVariable Long memberId,
+                                                                             @PathVariable Long bookId) {
+        SaleCheckResponseDto checkResponseDto = saleFacade.checkSaleByMemberIdAndBookId(memberId, bookId);
+        return ResponseEntity.ok(checkResponseDto);
     }
 }

--- a/src/main/java/store/ckin/api/sale/dto/request/SaleCheckByMemberRequestDto.java
+++ b/src/main/java/store/ckin/api/sale/dto/request/SaleCheckByMemberRequestDto.java
@@ -1,0 +1,19 @@
+package store.ckin.api.sale.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 회원 ID와 도서 ID를 통해 주문 리스트에 해당 주문이 존재하는지 확인하는 요청 DTO
+ *
+ * @author 정승조
+ * @version 2024. 03. 26.
+ */
+@Getter
+@NoArgsConstructor
+public class SaleCheckByMemberRequestDto {
+
+    private Long memberId;
+
+    private Long bookId;
+}

--- a/src/main/java/store/ckin/api/sale/dto/response/SaleCheckResponseDto.java
+++ b/src/main/java/store/ckin/api/sale/dto/response/SaleCheckResponseDto.java
@@ -1,0 +1,18 @@
+package store.ckin.api.sale.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 주문이 존재하는지 확인하는 응답 DTO
+ *
+ * @author 정승조
+ * @version 2024. 03. 26.
+ */
+
+@Getter
+@AllArgsConstructor
+public class SaleCheckResponseDto {
+
+    private Boolean isExist;
+}

--- a/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
+++ b/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
@@ -17,6 +17,7 @@ import store.ckin.api.pointhistory.dto.request.PointHistoryCreateRequestDto;
 import store.ckin.api.pointhistory.service.PointHistoryService;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
 import store.ckin.api.sale.dto.request.SaleDeliveryUpdateRequestDto;
+import store.ckin.api.sale.dto.response.SaleCheckResponseDto;
 import store.ckin.api.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
@@ -210,5 +211,17 @@ public class SaleFacade {
 
         // 주문 및 결제 상태 변경
         saleService.cancelSale(saleId);
+    }
+
+    /**
+     * 회원 ID와 도서 ID를 통해 주문 리스트에 해당 주문이 존재하는지 확인하는 메서드입니다.
+     *
+     * @param memberId 회원 ID
+     * @param bookId   도서 ID
+     * @return 주문 확인 응답 DTO
+     */
+    @Transactional(readOnly = true)
+    public SaleCheckResponseDto checkSaleByMemberIdAndBookId(Long memberId, Long bookId) {
+        return saleService.checkSaleByMemberIdAndBookId(memberId, bookId);
     }
 }

--- a/src/main/java/store/ckin/api/sale/repository/SaleRepositoryCustom.java
+++ b/src/main/java/store/ckin/api/sale/repository/SaleRepositoryCustom.java
@@ -4,6 +4,7 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.NoRepositoryBean;
 import store.ckin.api.common.dto.PagedResponse;
+import store.ckin.api.sale.dto.response.SaleCheckResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
@@ -51,4 +52,13 @@ public interface SaleRepositoryCustom {
      * @return 주문 응답 DTO 리스트
      */
     PagedResponse<List<SaleInfoResponseDto>> findAllByMemberId(Long memberId, Pageable pageable);
+
+    /**
+     * 회원 ID와 도서 ID로 주문을 조회하는 메서드입니다.
+     *
+     * @param memberId 회원 ID
+     * @param bookId   도서 ID
+     * @return 주문 체크 응답 DTO
+     */
+    SaleCheckResponseDto checkSaleByMemberIdAndBookId(Long memberId, Long bookId);
 }

--- a/src/main/java/store/ckin/api/sale/repository/SaleRepositoryImpl.java
+++ b/src/main/java/store/ckin/api/sale/repository/SaleRepositoryImpl.java
@@ -9,11 +9,13 @@ import store.ckin.api.booksale.entity.QBookSale;
 import store.ckin.api.common.domain.PageInfo;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.member.entity.QMember;
+import store.ckin.api.sale.dto.response.SaleCheckResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
 import store.ckin.api.sale.entity.QSale;
 import store.ckin.api.sale.entity.Sale;
+import store.ckin.api.sale.entity.SalePaymentStatus;
 
 /**
  * 주문 Repository Querydsl 구현 클래스입니다.
@@ -206,6 +208,23 @@ public class SaleRepositoryImpl extends QuerydslRepositorySupport implements Sal
                         .totalElements((int) totalElements)
                         .totalPages((int) Math.ceil((double) totalElements / pageable.getPageSize()))
                         .build());
+    }
+
+    @Override
+    public SaleCheckResponseDto checkSaleByMemberIdAndBookId(Long memberId, Long bookId) {
+
+        QSale sale = QSale.sale;
+        QBookSale bookSale = QBookSale.bookSale;
+
+        boolean isExist = from(sale)
+                .join(sale.bookSales, bookSale)
+                .where(sale.member.id.eq(memberId)
+                        .and(bookSale.book.bookId.eq(bookId))
+                        .and(sale.salePaymentStatus.eq(SalePaymentStatus.PAID)))
+                .fetchCount() > 0;
+
+
+        return new SaleCheckResponseDto(isExist);
     }
 
 }

--- a/src/main/java/store/ckin/api/sale/service/SaleService.java
+++ b/src/main/java/store/ckin/api/sale/service/SaleService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.sale.dto.request.SaleCreateNoBookRequestDto;
 import store.ckin.api.sale.dto.request.SaleDeliveryUpdateRequestDto;
+import store.ckin.api.sale.dto.response.SaleCheckResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
@@ -99,4 +100,12 @@ public interface SaleService {
      */
     void cancelSale(Long saleId);
 
+    /**
+     * 회원 ID와 도서 ID를 통해 주문 리스트에 해당 주문이 존재하는지 확인하는 메서드입니다.
+     *
+     * @param memberId 회원 ID
+     * @param bookId   도서 ID
+     * @return 주문 확인 응답 DTO
+     */
+    SaleCheckResponseDto checkSaleByMemberIdAndBookId(Long memberId, Long bookId);
 }

--- a/src/main/java/store/ckin/api/sale/service/impl/SaleServiceImpl.java
+++ b/src/main/java/store/ckin/api/sale/service/impl/SaleServiceImpl.java
@@ -20,6 +20,7 @@ import store.ckin.api.payment.entity.Payment;
 import store.ckin.api.payment.repository.PaymentRepository;
 import store.ckin.api.sale.dto.request.SaleCreateNoBookRequestDto;
 import store.ckin.api.sale.dto.request.SaleDeliveryUpdateRequestDto;
+import store.ckin.api.sale.dto.response.SaleCheckResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
@@ -250,5 +251,12 @@ public class SaleServiceImpl implements SaleService {
         paymentRepository.findBySale_SaleId(saleId)
                 .ifPresent(Payment::cancelPayment);
 
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SaleCheckResponseDto checkSaleByMemberIdAndBookId(Long memberId, Long bookId) {
+
+        return saleRepository.checkSaleByMemberIdAndBookId(memberId, bookId);
     }
 }

--- a/src/test/java/store/ckin/api/sale/controller/SaleControllerTest.java
+++ b/src/test/java/store/ckin/api/sale/controller/SaleControllerTest.java
@@ -47,6 +47,7 @@ import store.ckin.api.payment.dto.response.PaymentResponseDto;
 import store.ckin.api.payment.entity.PaymentStatus;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
 import store.ckin.api.sale.dto.request.SaleDeliveryUpdateRequestDto;
+import store.ckin.api.sale.dto.response.SaleCheckResponseDto;
 import store.ckin.api.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
@@ -809,5 +810,31 @@ class SaleControllerTest {
                 ));
 
         verify(saleFacade, times(1)).cancelSale(anyLong());
+    }
+
+    @Test
+    @DisplayName("회원 ID와 도서 ID를 통해 주문이 진행되었는지 확인하는 테스트")
+    void testCheckSaleByMemberIdAndBookId() throws Exception {
+
+        SaleCheckResponseDto responseDto = new SaleCheckResponseDto(true);
+
+        given(saleFacade.checkSaleByMemberIdAndBookId(anyLong(), anyLong()))
+                .willReturn(responseDto);
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/sales/check/{memberId}/{bookId}", 1L, 1L))
+                .andExpect(status().isOk())
+                .andDo(document("sale/checkSaleByMemberIdAndBookId/success",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("memberId").description("회원 ID"),
+                                parameterWithName("bookId").description("도서 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("isExist").description("주문 여부")
+                        )
+                ));
+
+        verify(saleFacade, times(1)).checkSaleByMemberIdAndBookId(anyLong(), anyLong());
     }
 }

--- a/src/test/java/store/ckin/api/sale/facade/SaleFacadeTest.java
+++ b/src/test/java/store/ckin/api/sale/facade/SaleFacadeTest.java
@@ -3,6 +3,7 @@ package store.ckin.api.sale.facade;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -31,6 +32,7 @@ import store.ckin.api.payment.service.PaymentService;
 import store.ckin.api.pointhistory.service.PointHistoryService;
 import store.ckin.api.sale.dto.request.SaleCreateRequestDto;
 import store.ckin.api.sale.dto.request.SaleDeliveryUpdateRequestDto;
+import store.ckin.api.sale.dto.response.SaleCheckResponseDto;
 import store.ckin.api.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
@@ -519,5 +521,20 @@ class SaleFacadeTest {
         verify(saleService, times(1)).cancelSale(anyLong());
         verify(saleService, times(1)).getSaleDetail(anyLong());
         verify(memberService, times(1)).updateCancelSalePoint(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("주문 확인 테스트 (도서 ID와 회원 ID를 통해 조회)")
+    void testCheckSaleByMemberIdAndBookId() {
+
+        SaleCheckResponseDto responseDto = new SaleCheckResponseDto(true);
+
+        given(saleService.checkSaleByMemberIdAndBookId(anyLong(), anyLong()))
+                .willReturn(responseDto);
+
+        SaleCheckResponseDto actual = saleFacade.checkSaleByMemberIdAndBookId(1L, 1L);
+
+        assertTrue(actual.getIsExist());
+        verify(saleService, times(1)).checkSaleByMemberIdAndBookId(1L, 1L);
     }
 }

--- a/src/test/java/store/ckin/api/sale/repository/SaleRepositoryTest.java
+++ b/src/test/java/store/ckin/api/sale/repository/SaleRepositoryTest.java
@@ -3,6 +3,7 @@ package store.ckin.api.sale.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -22,6 +23,7 @@ import store.ckin.api.common.domain.PageInfo;
 import store.ckin.api.common.dto.PagedResponse;
 import store.ckin.api.grade.entity.Grade;
 import store.ckin.api.member.entity.Member;
+import store.ckin.api.sale.dto.response.SaleCheckResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
@@ -400,7 +402,44 @@ class SaleRepositoryTest {
                 () -> assertEquals(1, pageInfo.getTotalElements()),
                 () -> assertEquals(1, pageInfo.getTotalPages())
         );
+    }
+
+    @Test
+    @DisplayName("주문 확인 - 회원 ID와 도서 ID로 주문 조회 테스트")
+    void testCheckSaleByMemberIdAndBookId() {
+
+        Sale sale = Sale.builder()
+                .member(member)
+                .saleNumber(saleNumber)
+                .saleTitle("홍길동전")
+                .saleOrdererName("정승조")
+                .saleOrdererContact("01012341234")
+                .saleReceiverName("정승조")
+                .saleReceiverContact("01012341234")
+                .saleReceiverAddress("광주광역시 동구 조선대 5길 IT 융합대학")
+                .saleDate(LocalDateTime.now())
+                .saleShippingDate(LocalDateTime.now())
+                .saleDeliveryDate(LocalDate.now().plusDays(2))
+                .saleDeliveryStatus(DeliveryStatus.READY)
+                .saleDeliveryFee(3000)
+                .salePointUsage(1000)
+                .salePaymentStatus(SalePaymentStatus.PAID)
+                .saleShippingPostCode("123456")
+                .build();
+
+        bookSale = BookSale.builder()
+                .pk(new BookSale.Pk(sale.getSaleId(), book.getBookId()))
+                .book(book)
+                .build();
+
+        entityManager.persist(sale);
+
+        entityManager.flush();
 
 
+        SaleCheckResponseDto actual =
+                saleRepository.checkSaleByMemberIdAndBookId(member.getId(), book.getBookId());
+
+        assertFalse(actual.getIsExist());
     }
 }

--- a/src/test/java/store/ckin/api/sale/service/impl/SaleServiceImplTest.java
+++ b/src/test/java/store/ckin/api/sale/service/impl/SaleServiceImplTest.java
@@ -34,6 +34,7 @@ import store.ckin.api.member.repository.MemberRepository;
 import store.ckin.api.payment.repository.PaymentRepository;
 import store.ckin.api.sale.dto.request.SaleCreateNoBookRequestDto;
 import store.ckin.api.sale.dto.request.SaleDeliveryUpdateRequestDto;
+import store.ckin.api.sale.dto.response.SaleCheckResponseDto;
 import store.ckin.api.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.api.sale.dto.response.SaleResponseDto;
 import store.ckin.api.sale.dto.response.SaleWithBookResponseDto;
@@ -491,5 +492,21 @@ class SaleServiceImplTest {
 
         verify(saleRepository, times(1)).findById(anyLong());
         verify(paymentRepository, times(1)).findBySale_SaleId(anyLong());
+    }
+
+    @Test
+    @DisplayName("주문 확인 테스트")
+    void testCheckSaleByMemberIdAndBookId() {
+
+        SaleCheckResponseDto responseDto = new SaleCheckResponseDto(false);
+
+        given(saleRepository.checkSaleByMemberIdAndBookId(anyLong(), anyLong()))
+                .willReturn(responseDto);
+
+        SaleCheckResponseDto checkResponseDto = saleService.checkSaleByMemberIdAndBookId(1L, 1L);
+
+        assertEquals(responseDto, checkResponseDto);
+        verify(saleRepository, times(1)).checkSaleByMemberIdAndBookId(anyLong(), anyLong());
+
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[[QA] 미주문 시에도 리뷰 작성 가능](https://github.com/nhnacademy-be4-ckin/ckin-management/issues/50)

## 📝 작업 내용

회원 ID와 도서 ID를 통해 해당 회원이 도서에 대한 주문 정보가 존재하는지 체크하는 로직을 추가하였습니다.
추가적으로, 주문의 상태가 결제 완료(PAID)인 경우에만 리뷰를 작성할 수 있도록 하였습니다.
