### PR TITLE
[FIX] 주문 포인트 사용 버그 수정

### DIFF
--- a/src/main/java/store/ckin/api/member/exception/MemberPointNotEnoughException.java
+++ b/src/main/java/store/ckin/api/member/exception/MemberPointNotEnoughException.java
@@ -10,7 +10,7 @@ import store.ckin.api.advice.exception.GeneralBadRequestException;
  */
 public class MemberPointNotEnoughException extends GeneralBadRequestException {
 
-    public MemberPointNotEnoughException(Long memberId) {
-        super(String.format("보유 포인트보다 더 많은 포인트를 사용할 수 없습니다. [memberId = %d]", memberId));
+    public MemberPointNotEnoughException() {
+        super("보유 포인트보다 더 많은 포인트를 사용할 수 없습니다.");
     }
 }

--- a/src/main/java/store/ckin/api/member/exception/MemberPointNotEnoughException.java
+++ b/src/main/java/store/ckin/api/member/exception/MemberPointNotEnoughException.java
@@ -1,0 +1,16 @@
+package store.ckin.api.member.exception;
+
+import store.ckin.api.advice.exception.GeneralBadRequestException;
+
+/**
+ * 보유 포인트보다 더 많은 포인트를 사용할 경우 호출되는 Exception 입니다.
+ *
+ * @author 정승조
+ * @version 2024. 03. 27.
+ */
+public class MemberPointNotEnoughException extends GeneralBadRequestException {
+
+    public MemberPointNotEnoughException(Long memberId) {
+        super(String.format("보유 포인트보다 더 많은 포인트를 사용할 수 없습니다. [memberId = %d]", memberId));
+    }
+}

--- a/src/main/java/store/ckin/api/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/store/ckin/api/member/service/impl/MemberServiceImpl.java
@@ -45,6 +45,7 @@ import store.ckin.api.sale.repository.SaleRepository;
  * @author : jinwoolee
  * @version : 2024. 02. 16.
  */
+
 @Service
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
@@ -147,10 +148,10 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
 
         if (member.getPoint() < pointUsage) {
-            throw new MemberPointNotEnoughException(memberId);
+            throw new MemberPointNotEnoughException();
         }
 
-        member.updatePoint(pointUsage);
+        member.updatePoint(-pointUsage);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/store/ckin/api/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/store/ckin/api/member/service/impl/MemberServiceImpl.java
@@ -15,13 +15,18 @@ import store.ckin.api.member.domain.request.MemberEmailOnlyRequestDto;
 import store.ckin.api.member.domain.request.MemberOauthIdOnlyRequestDto;
 import store.ckin.api.member.domain.request.MemberPasswordRequestDto;
 import store.ckin.api.member.domain.request.MemberUpdateRequestDto;
-import store.ckin.api.member.domain.response.*;
+import store.ckin.api.member.domain.response.MemberAuthResponseDto;
+import store.ckin.api.member.domain.response.MemberDetailInfoResponseDto;
+import store.ckin.api.member.domain.response.MemberMyPageResponseDto;
+import store.ckin.api.member.domain.response.MemberOauthLoginResponseDto;
+import store.ckin.api.member.domain.response.MemberPasswordResponseDto;
 import store.ckin.api.member.entity.Member;
 import store.ckin.api.member.exception.MemberAlreadyExistsException;
 import store.ckin.api.member.exception.MemberCannotChangeStateException;
 import store.ckin.api.member.exception.MemberNotFoundException;
 import store.ckin.api.member.exception.MemberOauthNotFoundException;
 import store.ckin.api.member.exception.MemberPasswordCannotChangeException;
+import store.ckin.api.member.exception.MemberPointNotEnoughException;
 import store.ckin.api.member.repository.MemberRepository;
 import store.ckin.api.member.service.MemberService;
 import store.ckin.api.pointhistory.entity.PointHistory;
@@ -140,6 +145,10 @@ public class MemberServiceImpl implements MemberService {
     public void updatePoint(Long memberId, Integer pointUsage) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(memberId));
+
+        if (member.getPoint() < pointUsage) {
+            throw new MemberPointNotEnoughException(memberId);
+        }
 
         member.updatePoint(pointUsage);
     }

--- a/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
+++ b/src/main/java/store/ckin/api/sale/facade/SaleFacade.java
@@ -61,7 +61,7 @@ public class SaleFacade {
         bookSaleService.createBookSale(sale.getSaleId(), requestDto.getBookSaleList());
 
         if (requestDto.getMemberId() != null && requestDto.getPointUsage() > 0) {
-            memberService.updatePoint(requestDto.getMemberId(), -requestDto.getPointUsage());
+            memberService.updatePoint(requestDto.getMemberId(), requestDto.getPointUsage());
 
             PointHistoryCreateRequestDto pointHistoryCreateRequestDto = PointHistoryCreateRequestDto.builder()
                     .memberId(requestDto.getMemberId())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[[QA] 주문 시 포인트 사용](https://github.com/nhnacademy-be4-ckin/ckin-management/issues/59)

## 📝 작업 내용

사용자가 포인트를 마음대로 변경 후 주문을 하였을 경우 예외 처리가 되도록 변경하였습니다.

![image](https://github.com/nhnacademy-be4-ckin/ckin-api/assets/84575041/7f1a5204-1881-40c0-9611-ecc6ec01f1eb)

![image](https://github.com/nhnacademy-be4-ckin/ckin-api/assets/84575041/da6da732-5232-4e74-8f7b-10a90ef73453)

> 예외에서 memberId가 노출되는 점은 변경중입니다.
